### PR TITLE
Ignore paths (Fixes #3, #4)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,28 @@
 # Migration
 
+## v1.0 to v1.1
+
+### New Requirements
+
+None
+
+### New features
+
+- File paths matching `symfony/cache/Traits` are ignored.
+- The option `extra.composer-attribute-collection.ignore-paths` can be used to ignore paths.
+
+### Backward Incompatible Changes
+
+None
+
+### Deprecated Features
+
+None
+
+### Other Changes
+
+None
+
 <!--
 
 ## vX.x to vX.x

--- a/README.md
+++ b/README.md
@@ -88,6 +88,29 @@ could also use [spatie/file-system-watcher][], it only requires PHP.
 
 
 
+## Configuration
+
+### Ignoring paths ([root-only][])
+
+composer-attribute-collector inspects files that participate in the autoload process. This can cause
+issues with files that have side effects. For instance, `symfony/cache` is known to cause issues, so
+we're excluding paths matching `symfony/cache/Traits` from inspection. Additional paths can be
+specified using the `extra` section of `composer.json`:
+
+```json
+{
+  "extra": {
+    "composer-attribute-collector": {
+      "ignore-paths": [
+        "path/to/ignore"
+      ]
+    }
+  }
+}
+```
+
+
+
 ## Test drive with a Symfony app
 
 You can try the plugin with a fresh installation of Symfony.
@@ -124,6 +147,8 @@ Attributes::with(fn () => new Collection(
             [ ['debug:validator', 'Display validation constraints for classes'], \Symfony\Component\Validator\Command\DebugCommand::class ],
             [ ['translation:pull', 'Pull translations from a given provider.'], \Symfony\Component\Translation\Command\TranslationPullCommand::class ],
 ```
+
+We also have [a repository to test the Symfony usecase](https://github.com/olvlvl/composer-attribute-collector-usecase-symfony).
 
 
 
@@ -270,7 +295,8 @@ Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 
 
-[Composer]: https://getcomposer.org/
+[Composer]:  https://getcomposer.org/
+[root-only]: https://getcomposer.org/doc/04-schema.md#root-package
 [ICanBoogie/MessageBus]: https://github.com/ICanBoogie/MessageBus
 [spatie/file-system-watcher]: https://github.com/spatie/file-system-watcher
 [phpstorm-watchers]: https://www.jetbrains.com/help/phpstorm/using-file-watchers.html

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,11 @@
         "phpunit/phpunit": "^9.5"
     },
     "extra": {
-        "class": "olvlvl\\ComposerAttributeCollector\\Plugin"
+        "class": "olvlvl\\ComposerAttributeCollector\\Plugin",
+        "composer-attribute-collector": {
+            "ignore-paths": [
+                "IncompatibleSignature"
+            ]
+        }
     }
 }

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace olvlvl\ComposerAttributeCollector;
+
+use Composer\IO\IOInterface;
+
+interface Filter
+{
+    /**
+     * @param class-string $class
+     */
+    public function filter(string $filepath, string $class, IOInterface $io): bool;
+}

--- a/src/Filter/Chain.php
+++ b/src/Filter/Chain.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * (c) Olivier Laviale <olivier.laviale@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace olvlvl\ComposerAttributeCollector\Filter;
+
+use Composer\IO\IOInterface;
+use olvlvl\ComposerAttributeCollector\Filter;
+
+final class Chain implements Filter
+{
+    /**
+     * @param iterable<Filter> $filters
+     */
+    public function __construct(
+        private iterable $filters
+    ) {
+    }
+
+    public function filter(string $filepath, string $class, IOInterface $io): bool
+    {
+        foreach ($this->filters as $filter) {
+            if ($filter->filter($filepath, $class, $io) === false) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Filter/ContentFilter.php
+++ b/src/Filter/ContentFilter.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * (c) Olivier Laviale <olivier.laviale@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace olvlvl\ComposerAttributeCollector\Filter;
+
+use Composer\IO\IOInterface;
+use olvlvl\ComposerAttributeCollector\Filter;
+
+use function assert;
+use function file_get_contents;
+use function is_string;
+use function preg_match;
+use function str_contains;
+
+final class ContentFilter implements Filter
+{
+    public function filter(string $filepath, string $class, IOInterface $io): bool
+    {
+        $content = file_get_contents($filepath);
+
+        assert(is_string($content));
+
+        // No hint of attribute usage.
+        if (!str_contains($content, '#[')) {
+            return false;
+        }
+
+        // Hint of an attribute class.
+        if (preg_match('/#\[\\\?Attribute[\]\(]/', $content)) {
+            $io->debug("Discarding '$class' because it looks like an attribute");
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Filter/InterfaceFilter.php
+++ b/src/Filter/InterfaceFilter.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * (c) Olivier Laviale <olivier.laviale@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace olvlvl\ComposerAttributeCollector\Filter;
+
+use Composer\IO\IOInterface;
+use olvlvl\ComposerAttributeCollector\Filter;
+use Throwable;
+
+use function interface_exists;
+
+final class InterfaceFilter implements Filter
+{
+    public function filter(string $filepath, string $class, IOInterface $io): bool
+    {
+        try {
+            if (interface_exists($class)) {
+                return false;
+            }
+        } catch (Throwable $e) {
+            $io->warning("Discarding '$class' because an error occurred during loading: {$e->getMessage()}");
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Filter/PathFilter.php
+++ b/src/Filter/PathFilter.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * (c) Olivier Laviale <olivier.laviale@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace olvlvl\ComposerAttributeCollector\Filter;
+
+use Composer\IO\IOInterface;
+use olvlvl\ComposerAttributeCollector\Filter;
+
+use function str_contains;
+
+final class PathFilter implements Filter
+{
+    /**
+     * @param string[] $matches
+     */
+    public function __construct(
+        private array $matches
+    ) {
+    }
+
+    public function filter(string $filepath, string $class, IOInterface $io): bool
+    {
+        foreach ($this->matches as $match) {
+            if (str_contains($filepath, $match)) {
+                $io->debug("Discarding '$class' because its path matches '$match'");
+
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/Acme/PSR4/IncompatibleSignature.php
+++ b/tests/Acme/PSR4/IncompatibleSignature.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Acme\PSR4;
+
+use Acme\Attribute\Handler;
+use IteratorAggregate;
+
+#[Handler]
+class IncompatibleSignature implements IteratorAggregate
+{
+    public function getIterator(string $invalid): void
+    {
+        // TODO: Implement getIterator() method.
+    }
+}

--- a/tests/ClassMapBuilderTest.php
+++ b/tests/ClassMapBuilderTest.php
@@ -47,6 +47,7 @@ final class ClassMapBuilderTest extends TestCase
             'Acme\PSR4\SubscriberB' => "$cwd/tests/Acme/PSR4/SubscriberB.php",
             'Acme\Presentation\ImageController' => "$cwd/tests/Acme/ClassMap/controllers.php",
             'Acme\Presentation\FileController' => "$cwd/tests/Acme/ClassMap/controllers.php",
+            'Acme\PSR4\IncompatibleSignature' => "$cwd/tests/Acme/PSR4/IncompatibleSignature.php",
             'Acme\PSR4\MissingInterface' => "$cwd/tests/Acme/PSR4/MissingInterface.php",
             'Acme\PSR4\MissingParent' => "$cwd/tests/Acme/PSR4/MissingParent.php",
         ];

--- a/tests/Filter/ChainTest.php
+++ b/tests/Filter/ChainTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * (c) Olivier Laviale <olivier.laviale@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace tests\olvlvl\ComposerAttributeCollector\Filter;
+
+use Composer\IO\IOInterface;
+use olvlvl\ComposerAttributeCollector\Filter;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class ChainTest extends TestCase
+{
+    private const FILEPATH = "vendor/symfony/cache/Traits/RedisCluster5Proxy.php";
+    private const CLASSNAME = "RedisCluster5Proxy";
+
+    private IOInterface|MockObject $io;
+    private Filter|MockObject $ok;
+    private Filter|MockObject $ko;
+    private Filter|MockObject $no;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->io = $this->getMockBuilder(IOInterface::class)->getMock();
+
+        $ok = $this->ok = $this->getMockBuilder(Filter::class)->getMock();
+        $ok->method('filter')->with(self::FILEPATH, self::CLASSNAME, $this->io)->willReturn(true);
+
+        $ko = $this->ko = $this->getMockBuilder(Filter::class)->getMock();
+        $ko->method('filter')->with(self::FILEPATH, self::CLASSNAME, $this->io)->willReturn(false);
+
+        $no = $this->no = $this->getMockBuilder(Filter::class)->getMock();
+        $no->expects($this->never())->method('filter')->with(self::FILEPATH, self::CLASSNAME, $this->io);
+    }
+
+    public function testFilter_OkIfNoFalse()
+    {
+        $chain = new Filter\Chain([ $this->ok, $this->ok ]);
+
+        $actual = $chain->filter(self::FILEPATH, self::CLASSNAME, $this->io);
+
+        $this->assertTrue($actual);
+    }
+
+    public function testFilter_False()
+    {
+        $chain = new Filter\Chain([ $this->ko ]);
+
+        $actual = $chain->filter(self::FILEPATH, self::CLASSNAME, $this->io);
+
+        $this->assertFalse($actual);
+    }
+
+    public function testFilter_FalseBefore()
+    {
+        $chain = new Filter\Chain([ $this->ko, $this->no ]);
+
+        $actual = $chain->filter(self::FILEPATH, self::CLASSNAME, $this->io);
+
+        $this->assertFalse($actual);
+    }
+
+    public function testFilter_FalseAfter()
+    {
+        $chain = new Filter\Chain([ $this->ok, $this->ko, $this->no ]);
+
+        $actual = $chain->filter(self::FILEPATH, self::CLASSNAME, $this->io);
+
+        $this->assertFalse($actual);
+    }
+}

--- a/tests/Filter/ContentFilterCases/AttributeFullyQualifiedWithArgument.php
+++ b/tests/Filter/ContentFilterCases/AttributeFullyQualifiedWithArgument.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * (c) Olivier Laviale <olivier.laviale@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace tests\olvlvl\ComposerAttributeCollector\Filter\ContentFilterCases;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AttributeFullyQualifiedWithArgument
+{
+}

--- a/tests/Filter/ContentFilterCases/AttributeFullyQualifiedWithoutArgument.php
+++ b/tests/Filter/ContentFilterCases/AttributeFullyQualifiedWithoutArgument.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * (c) Olivier Laviale <olivier.laviale@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace tests\olvlvl\ComposerAttributeCollector\Filter\ContentFilterCases;
+
+#[\Attribute]
+class AttributeFullyQualifiedWithoutArgument
+{
+}

--- a/tests/Filter/ContentFilterCases/AttributeImportedWithArgument.php
+++ b/tests/Filter/ContentFilterCases/AttributeImportedWithArgument.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * (c) Olivier Laviale <olivier.laviale@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace tests\olvlvl\ComposerAttributeCollector\Filter\ContentFilterCases;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class AttributeImportedWithArgument
+{
+}

--- a/tests/Filter/ContentFilterCases/AttributeImportedWithoutArgument.php
+++ b/tests/Filter/ContentFilterCases/AttributeImportedWithoutArgument.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * (c) Olivier Laviale <olivier.laviale@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace tests\olvlvl\ComposerAttributeCollector\Filter\ContentFilterCases;
+
+use Attribute;
+
+#[Attribute]
+class AttributeImportedWithoutArgument
+{
+}

--- a/tests/Filter/ContentFilterCases/ClassWithAttribute.php
+++ b/tests/Filter/ContentFilterCases/ClassWithAttribute.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * (c) Olivier Laviale <olivier.laviale@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace tests\olvlvl\ComposerAttributeCollector\Filter\ContentFilterCases;
+
+#[SomeAttribute]
+class ClassWithAttribute
+{
+}

--- a/tests/Filter/ContentFilterCases/ClassWithoutAttribute.php
+++ b/tests/Filter/ContentFilterCases/ClassWithoutAttribute.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * (c) Olivier Laviale <olivier.laviale@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace tests\olvlvl\ComposerAttributeCollector\Filter\ContentFilterCases;
+
+class ClassWithoutAttribute
+{
+}

--- a/tests/Filter/ContentFilterTest.php
+++ b/tests/Filter/ContentFilterTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * (c) Olivier Laviale <olivier.laviale@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace tests\olvlvl\ComposerAttributeCollector\Filter;
+
+use Composer\IO\IOInterface;
+use olvlvl\ComposerAttributeCollector\Filter\ContentFilter;
+use PHPUnit\Framework\MockObject\MockObject as MockObjectAlias;
+use PHPUnit\Framework\TestCase;
+
+final class ContentFilterTest extends TestCase
+{
+    private ContentFilter $sut;
+    private MockObjectAlias|IOInterface $io;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sut = new ContentFilter();
+        $this->io = $this->getMockBuilder(IOInterface::class)->getMock();
+    }
+
+    /**
+     * @dataProvider provideAttribute
+     */
+    public function testAttribute(string $case)
+    {
+        $this->io->expects($this->once())
+            ->method('debug')
+            ->with("Discarding '$case' because it looks like an attribute");
+
+        $actual = $this->sut->filter(
+            __DIR__ . "/ContentFilterCases/$case.php",
+            $case,
+            $this->io
+        );
+
+        $this->assertFalse($actual);
+    }
+
+    public function provideAttribute(): array
+    {
+        return [
+
+            [ "AttributeFullyQualifiedWithoutArgument" ],
+            [ "AttributeFullyQualifiedWithArgument" ],
+            [ "AttributeImportedWithoutArgument" ],
+            [ "AttributeImportedWithArgument" ],
+
+        ];
+    }
+
+    /**
+     * @@dataProvider provideClass
+     */
+    public function testClass(string $case, bool $expected)
+    {
+        $this->io->expects($this->never())
+            ->method('debug')
+            ->with($this->anything());
+
+        $actual = $this->sut->filter(
+            __DIR__ . "/ContentFilterCases/$case.php",
+            $case,
+            $this->io
+        );
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function provideClass(): array
+    {
+        return [
+
+            [ "ClassWithoutAttribute", false ],
+            [ "ClassWithAttribute", true ],
+
+        ];
+    }
+}

--- a/tests/Filter/PathFilterTest.php
+++ b/tests/Filter/PathFilterTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * (c) Olivier Laviale <olivier.laviale@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace tests\olvlvl\ComposerAttributeCollector\Filter;
+
+use Composer\IO\IOInterface;
+use olvlvl\ComposerAttributeCollector\Filter\PathFilter;
+use PHPUnit\Framework\TestCase;
+
+final class PathFilterTest extends TestCase
+{
+    private PathFilter $filter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filter = new PathFilter([
+            "symfony/cache/Traits"
+        ]);
+    }
+
+    /**
+     * @dataProvider provideFilter
+     */
+    public function testFilter(string $filepath, string $class, bool $expected): void
+    {
+        $io = $this->getMockBuilder(IOInterface::class)->getMock();
+
+        if ($expected) {
+            $io
+                ->expects($this->never())
+                ->method('debug');
+        } else {
+            $io
+                ->expects($this->once())
+                ->method('debug')
+                ->with($this->stringStartsWith("Discarding '$class' because its path matches"));
+        }
+
+        $actual = $this->filter->filter($filepath, $class, $io);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function provideFilter(): array
+    {
+        return [
+
+            [ "vendor/symfony/cache/Traits/RedisCluster5Proxy.php", "RedisCluster5Proxy", false ],
+            [ "vendor/symfony/routing/Route.php", "Route", true ],
+
+        ];
+    }
+}

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -17,6 +17,7 @@ use Acme\Attribute\Subscribe;
 use Acme\PSR4\Presentation\ArticleController;
 use Composer\Composer;
 use Composer\IO\NullIO;
+use Composer\Package\RootPackageInterface;
 use olvlvl\ComposerAttributeCollector\Attributes;
 use olvlvl\ComposerAttributeCollector\AutoloadsBuilder;
 use olvlvl\ComposerAttributeCollector\Plugin;
@@ -30,7 +31,24 @@ final class PluginTest extends TestCase
 {
     public function testDump(): void
     {
+        $extra = [
+            Plugin::EXTRA => [
+                Plugin::EXTRA_IGNORE_PATHS => [
+                    'IncompatibleSignature'
+                ]
+            ]
+        ];
+
+        $package = $this->getMockBuilder(RootPackageInterface::class)->getMock();
+        $package
+            ->method('getExtra')
+            ->willReturn($extra);
+
         $composer = $this->getMockBuilder(Composer::class)->getMock();
+        $composer
+            ->method('getPackage')
+            ->willReturn($package);
+
         $autoloadsBuilder = $this->getMockBuilder(AutoloadsBuilder::class)->getMock();
         $autoloadsBuilder
             ->method('buildAutoloads')


### PR DESCRIPTION
This PR adds a filter to ignore paths.

`symfony/cache/Traits` is always ignored because it's know to cause issues. The option `extra.composer-attribute-collection.ignore-paths` can be used to ignore additional paths.

I created a use case over here for testing: https://github.com/olvlvl/composer-attribute-collector-usecase-symfony