### PR TITLE
Introduce caching in multiple steps (Fix #6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.composer-attribute-collector
 .phpunit.result.cache
 vendor
 composer.lock

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -11,6 +11,7 @@ None
 - [#11](https://github.com/olvlvl/composer-attribute-collector/pull/11) Attribute instantiation errors are decorated to help find origin (@withinboredom @olvlvl)
 - [#12](https://github.com/olvlvl/composer-attribute-collector/pull/12) `Attributes::filterTargetClasses()` can filter target classes using a predicate (@olvlvl)
 - [#12](https://github.com/olvlvl/composer-attribute-collector/pull/12) `Attributes::filterTargetMethods()` can filter target methods using a predicate (@olvlvl)
+- [#10](https://github.com/olvlvl/composer-attribute-collector/pull/10) 3 types of cache speed up generation by limiting updates to changed files (@xepozz @olvlvl)
 
 ### Backward Incompatible Changes
 

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ test-coveralls: test-dependencies
 
 .PHONY: test-cleanup
 test-cleanup:
+	@rm -rf .composer-attribute-collector/*
 	@rm -rf tests/sandbox/*
 
 .PHONY: test-container

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Later, these targets can be retrieved through a convenient interface.
 - No dependency (except Composer of course).
 - A single interface to get attribute targets.
 - A single interface to get class attributes.
+- 3 types of cache speed up generation by limiting updates to changed files.
 
 
 
@@ -73,21 +74,23 @@ The plugin is currently experimental and its interface subject to change. Also, 
 class and method targets. Please [contribute](CONTRIBUTING.md) if you're interested in shaping its
 future.
 
+**Note:** The plugin creates a `.composer-attribute-collector` directory to store caches, you might
+want to add it to your `.gitignore` file.
+
 
 
 ## Frequently Asked Questions
 
 **Do I need to generate an optimized autoloader?**
 
-You don't need to generate an optimized autoloader for this to work. The
-plugin uses code similar to Composer to find classes. Anything that works with Composer should work
-with the plugin.
+You don't need to generate an optimized autoloader for this to work. The plugin uses code similar
+to Composer to find classes. Anything that works with Composer should work with the plugin.
 
 **Can I use the plugin during development?**
 
 Yes, you can use the plugin during development, but keep in mind the attributes file is only
-generated after the autoloader is dumped. If you modify attributes you'll have to
-run `composer dump` to refresh the attributes file.
+generated after the autoloader is dumped. If you modify attributes you'll have to run
+`composer dump` to refresh the attributes file.
 
 As a workaround you could have watchers on the directories that contain classes with attributes to
 run `XDEBUG_MODE=off composer dump` when you make changes. [PhpStorm offers file watchers][phpstorm-watchers]. You could also use [spatie/file-system-watcher][], it only requires PHP.
@@ -295,6 +298,8 @@ final class IsAdmin implements Voter
     // ...
 }
 ```
+
+
 
 ## Using Attributes
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,6 +4,7 @@
     <file>src</file>
     <file>tests</file>
     <exclude-pattern>tests/sandbox/*</exclude-pattern>
+    <exclude-pattern>tests/sandbox-memoize-classmap/*</exclude-pattern>
 
 	<arg name="colors"/>
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,6 @@
 parameters:
+  bootstrapFiles:
+  - tests/bootstrap.php
   level: max
   paths:
     - src

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd" colors="true"
-		 bootstrap="./vendor/autoload.php">
+		 bootstrap="./tests/bootstrap.php">
 	<coverage>
 		<include>
 			<directory suffix=".php">./src</directory>

--- a/src/ClassAttributeCollector.php
+++ b/src/ClassAttributeCollector.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace olvlvl\ComposerAttributeCollector;
+
+use Attribute;
+use Composer\IO\IOInterface;
+use ReflectionAttribute;
+use ReflectionClass;
+use ReflectionException;
+
+/**
+ * @internal
+ */
+class ClassAttributeCollector
+{
+    public function __construct(
+        private IOInterface $io,
+    ) {
+    }
+
+    /**
+     * @param class-string $class
+     *
+     * @return array{
+     *     array<array{ class-string, array<int|string, mixed> }>,
+     *     array<array{ class-string, array<int|string, mixed>, non-empty-string }>
+     * }
+     *     Where `0` is an array of class attributes, and `1` is an array of method attributes.
+     * @throws ReflectionException
+     */
+    public function collectAttributes(string $class): array
+    {
+        $classReflection = new ReflectionClass($class);
+
+        if (self::isAttribute($classReflection)) {
+            return [ [], [] ];
+        }
+
+        $classAttributes = [];
+        $attributes = $classReflection->getAttributes();
+
+        foreach ($attributes as $attribute) {
+            if (self::isAttributeIgnored($attribute)) {
+                continue;
+            }
+
+            $this->io->debug("Found attribute {$attribute->getName()} on $class");
+
+            $classAttributes[] = [ $attribute->getName(), $attribute->getArguments() ];
+        }
+
+        $methodAttributes = [];
+
+        foreach ($classReflection->getMethods() as $methodReflection) {
+            foreach ($methodReflection->getAttributes() as $attribute) {
+                if (self::isAttributeIgnored($attribute)) {
+                    continue;
+                }
+
+                $method = $methodReflection->name;
+                assert($method !== '');
+
+                $this->io->debug("Found attribute {$attribute->getName()} on $class::$method");
+
+                $methodAttributes[] = [ $attribute->getName(), $attribute->getArguments(), $method ];
+            }
+        }
+
+        return [ $classAttributes, $methodAttributes ];
+    }
+
+    /**
+     * Determines if a class is an attribute.
+     *
+     * @param ReflectionClass<object> $classReflection
+     */
+    private static function isAttribute(ReflectionClass $classReflection): bool
+    {
+        foreach ($classReflection->getAttributes() as $attribute) {
+            if ($attribute->getName() === Attribute::class) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param ReflectionAttribute<object> $attribute
+     */
+    private static function isAttributeIgnored(ReflectionAttribute $attribute): bool
+    {
+        static $ignored = [
+            \ReturnTypeWillChange::class => true,
+        ];
+
+        return isset($ignored[$attribute->getName()]);
+    }
+}

--- a/src/ClassMapBuilder.php
+++ b/src/ClassMapBuilder.php
@@ -9,7 +9,6 @@
 
 namespace olvlvl\ComposerAttributeCollector;
 
-use Composer\ClassMapGenerator\ClassMapGenerator;
 use Composer\Pcre\Preg;
 use Composer\Util\Filesystem;
 use Composer\Util\Platform;
@@ -40,9 +39,12 @@ class ClassMapBuilder
      */
     public function buildClassMap(array $autoloads): array
     {
+        $filesystem = new Filesystem();
+        // @phpstan-ignore-next-line
+        $basePath = $filesystem->normalizePath(realpath(realpath(Platform::getCwd())));
+        $classMapGenerator = new MemoizeClassMapGenerator($basePath);
+
         $excluded = $autoloads['exclude-from-classmap'];
-        $classMapGenerator = new ClassMapGenerator();
-        $classMapGenerator->avoidDuplicateScans();
 
         foreach ($autoloads['classmap'] as $dir) {
             // @phpstan-ignore-next-line
@@ -59,10 +61,6 @@ class ClassMapBuilder
         }
 
         krsort($namespacesToScan);
-
-        $filesystem = new Filesystem();
-        // @phpstan-ignore-next-line
-        $basePath = $filesystem->normalizePath(realpath(realpath(Platform::getCwd())));
 
         foreach ($namespacesToScan as $namespace => $groups) {
             foreach ($groups as $group) {
@@ -85,7 +83,7 @@ class ClassMapBuilder
             }
         }
 
-        return $classMapGenerator->getClassMap()->getMap();
+        return $classMapGenerator->getMap();
     }
 
     /**

--- a/src/Collector.php
+++ b/src/Collector.php
@@ -9,10 +9,6 @@
 
 namespace olvlvl\ComposerAttributeCollector;
 
-use ReflectionAttribute;
-use ReflectionClass;
-use ReflectionMethod;
-
 /**
  * Collects classes and methods with attributes.
  *
@@ -31,21 +27,29 @@ final class Collector
     public array $methods = [];
 
     /**
-     * @param ReflectionAttribute<object> $attribute
-     * @param ReflectionClass<object> $class
+     * @param array<array{ class-string, array<int|string, mixed> }> $attributes
+     *     An array of method attributes, where `0` is an attribute class, `1` the attributes arguments.
+     * @param class-string $class
+     *     The target class.
      */
-    public function addTargetClass(ReflectionAttribute $attribute, ReflectionClass $class): void
+    public function addClassAttributes(array $attributes, string $class): void
     {
-        $this->classes[$attribute->getName()][]
-            = new TargetClassRaw($attribute->getArguments(), $class->name);
+        foreach ($attributes as [ $attribute, $arguments ]) {
+            $this->classes[$attribute][] = new TargetClassRaw($arguments, $class);
+        }
     }
 
     /**
-     * @param ReflectionAttribute<object> $attribute
+     * @param array<array{ class-string, array<int|string, mixed>, string }> $attributes
+     *     An array of method attributes, where `0` is an attribute class, `1` the attributes arguments,
+     *     and `2` the method.
+     * @param class-string $class
+     *     The target class.
      */
-    public function addTargetMethod(ReflectionAttribute $attribute, ReflectionMethod $method): void
+    public function addMethodAttributes(array $attributes, string $class): void
     {
-        $this->methods[$attribute->getName()][]
-            = new TargetMethodRaw($attribute->getArguments(), $method->class, $method->name);
+        foreach ($attributes as [ $attribute, $arguments, $method ]) {
+            $this->methods[$attribute][] = new TargetMethodRaw($arguments, $class, $method);
+        }
     }
 }

--- a/src/Datastore.php
+++ b/src/Datastore.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace olvlvl\ComposerAttributeCollector;
+
+interface Datastore
+{
+    /**
+     * @return array<int|string, mixed>
+     */
+    public function get(string $key): array;
+
+    /**
+     * @param array<int|string, mixed> $data
+     */
+    public function set(string $key, array $data): void;
+}

--- a/src/Datastore.php
+++ b/src/Datastore.php
@@ -2,6 +2,9 @@
 
 namespace olvlvl\ComposerAttributeCollector;
 
+/**
+ * @internal
+ */
 interface Datastore
 {
     /**

--- a/src/FileDatastore.php
+++ b/src/FileDatastore.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace olvlvl\ComposerAttributeCollector;
+
+use function file_exists;
+use function file_get_contents;
+use function file_put_contents;
+use function is_dir;
+use function mkdir;
+use function serialize;
+use function unserialize;
+
+use const DIRECTORY_SEPARATOR;
+
+final class FileDatastore implements Datastore
+{
+    public function __construct(
+        private string $dir
+    ) {
+        if (!is_dir($dir)) {
+            mkdir($dir);
+        }
+    }
+
+    public function get(string $key): array
+    {
+        $filename = $this->dir . DIRECTORY_SEPARATOR . $key;
+
+        if (!file_exists($filename)) {
+            return [];
+        }
+
+        /** @phpstan-ignore-next-line */
+        return unserialize(file_get_contents($filename));
+    }
+
+    public function set(string $key, array $data): void
+    {
+        $filename = $this->dir . DIRECTORY_SEPARATOR . $key;
+
+        file_put_contents($filename, serialize($data));
+    }
+}

--- a/src/FileDatastore.php
+++ b/src/FileDatastore.php
@@ -12,11 +12,19 @@ use function unserialize;
 
 use const DIRECTORY_SEPARATOR;
 
+/**
+ * @internal
+ */
 final class FileDatastore implements Datastore
 {
+    /**
+     * @param non-empty-string $dir
+     */
     public function __construct(
         private string $dir
     ) {
+        assert($dir !== '');
+
         if (!is_dir($dir)) {
             mkdir($dir);
         }

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -4,6 +4,9 @@ namespace olvlvl\ComposerAttributeCollector;
 
 use Composer\IO\IOInterface;
 
+/**
+ * @internal
+ */
 interface Filter
 {
     /**

--- a/src/MemoizeAttributeCollector.php
+++ b/src/MemoizeAttributeCollector.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace olvlvl\ComposerAttributeCollector;
+
+use Composer\IO\IOInterface;
+use ReflectionException;
+
+use function array_filter;
+use function filemtime;
+
+use const ARRAY_FILTER_USE_KEY;
+
+/**
+ * @internal
+ */
+class MemoizeAttributeCollector
+{
+    private const KEY = 'attributes';
+
+    /**
+     * @var array<class-string, array{
+     *     int,
+     *     array<array{ class-string, array<int|string, mixed> }>,
+     *     array<array{ class-string, array<int|string, mixed>, non-empty-string }>
+     * }>
+     *     Where _key_ is a class and _value is an array where `0` is a timestamp, `1` is an array of class attributes,
+     *     and `2` is an array of method attributes.
+     */
+    private array $state;
+
+    public function __construct(
+        private ClassAttributeCollector $classAttributeCollector,
+        private Datastore $datastore,
+        private IOInterface $io,
+    ) {
+        /** @phpstan-ignore-next-line */
+        $this->state = $this->datastore->get(self::KEY);
+    }
+
+    /**
+     * @param array<class-string, string> $classMap
+     *     Where _key_ is a class and _value_ its pathname.
+     *
+     * @throws ReflectionException
+     */
+    public function collectAttributes(array $classMap): Collector
+    {
+        $filterClasses = [];
+        $classAttributeCollector = $this->classAttributeCollector;
+        $collector = new Collector();
+
+        foreach ($classMap as $class => $filepath) {
+            $filterClasses[$class] = true;
+            [ $timestamp, $classAttributes, $methodAttributes ] = $this->state[$class] ?? [ 0, [], [] ];
+
+            $mtime = filemtime($filepath);
+
+            if ($timestamp < $mtime) {
+                $this->io->debug("Refresh attributes of class '$class' in '$filepath' ($timestamp < $mtime)");
+                [ $classAttributes, $methodAttributes ] = $classAttributeCollector->collectAttributes($class);
+                $this->state[$class] = [ time(), $classAttributes, $methodAttributes ];
+            }
+
+            $collector->addClassAttributes($classAttributes, $class);
+            $collector->addMethodAttributes($methodAttributes, $class);
+        }
+
+        /**
+         * Classes might have been removed, we need to filter according to the classes found.
+         */
+        $this->state = array_filter(
+            $this->state,
+            static fn(string $k): bool => $filterClasses[$k] ?? false,
+            ARRAY_FILTER_USE_KEY
+        );
+
+        $this->datastore->set(self::KEY, $this->state);
+
+        return $collector;
+    }
+}

--- a/src/MemoizeClassMapFilter.php
+++ b/src/MemoizeClassMapFilter.php
@@ -12,6 +12,9 @@ use function time;
 
 use const ARRAY_FILTER_USE_KEY;
 
+/**
+ * @internal
+ */
 class MemoizeClassMapFilter
 {
     private const KEY = 'filtered';
@@ -65,7 +68,7 @@ class MemoizeClassMapFilter
          */
         $this->state = array_filter(
             $this->state,
-            fn(string $k): bool => $paths[$k] ?? false,
+            static fn(string $k): bool => $paths[$k] ?? false,
             ARRAY_FILTER_USE_KEY
         );
 

--- a/src/MemoizeClassMapFilter.php
+++ b/src/MemoizeClassMapFilter.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace olvlvl\ComposerAttributeCollector;
+
+use Closure;
+use Composer\IO\IOInterface;
+
+use function array_filter;
+use function filemtime;
+use function is_int;
+use function time;
+
+use const ARRAY_FILTER_USE_KEY;
+
+class MemoizeClassMapFilter
+{
+    private const KEY = 'filtered';
+
+    /**
+     * @var array<non-empty-string, array{ int, bool }>
+     */
+    private array $state;
+
+    public function __construct(
+        private Datastore $datastore,
+        private IOInterface $io,
+    ) {
+        /** @phpstan-ignore-next-line */
+        $this->state = $this->datastore->get(self::KEY);
+    }
+
+    /**
+     * @param array<class-string, non-empty-string> $classMap
+     *     Where _key_ is a class and _value_ its pathname.
+     * @param Closure(class-string, non-empty-string): bool $filter
+     *
+     * @return array<class-string, non-empty-string>
+     */
+    public function filter(array $classMap, Closure $filter): array
+    {
+        $filtered = [];
+        $paths = [];
+
+        foreach ($classMap as $class => $pathname) {
+            $paths[$pathname] = true;
+            [ $timestamp, $keep ] = $this->state[$pathname] ?? [ 0, false ];
+
+            $mtime = filemtime($pathname);
+
+            assert(is_int($mtime));
+
+            if ($timestamp < $mtime) {
+                $this->io->debug("Refresh filtered for '$pathname' ($timestamp < $mtime)");
+                $keep = $filter($class, $pathname);
+                $this->state[$pathname] = [ time(), $keep ];
+            }
+
+            if ($keep) {
+                $filtered[$class] = $pathname;
+            }
+        }
+
+        /**
+         * Paths might have been removed, we need to filter according to the paths found.
+         */
+        $this->state = array_filter(
+            $this->state,
+            fn(string $k): bool => $paths[$k] ?? false,
+            ARRAY_FILTER_USE_KEY
+        );
+
+        $this->datastore->set(self::KEY, $this->state);
+
+        return $filtered;
+    }
+}

--- a/src/MemoizeClassMapGenerator.php
+++ b/src/MemoizeClassMapGenerator.php
@@ -14,6 +14,9 @@ use function time;
 
 use const ARRAY_FILTER_USE_KEY;
 
+/**
+ * @internal
+ */
 class MemoizeClassMapGenerator
 {
     private const KEY = 'classmap';

--- a/src/MemoizeClassMapGenerator.php
+++ b/src/MemoizeClassMapGenerator.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace olvlvl\ComposerAttributeCollector;
+
+use Closure;
+use Composer\ClassMapGenerator\ClassMapGenerator;
+use RuntimeException;
+
+use function array_merge;
+use function array_values;
+use function file_exists;
+use function file_get_contents;
+use function file_put_contents;
+use function filemtime;
+use function is_dir;
+use function is_string;
+use function mkdir;
+use function preg_replace;
+use function serialize;
+use function str_starts_with;
+use function strlen;
+use function substr;
+use function unserialize;
+
+use const DIRECTORY_SEPARATOR;
+
+/**
+ * *Note:* We have to extend {@link ClassMapGenerator} because there's no interface available.
+ */
+class MemoizeClassMapGenerator
+{
+    private const CACHE_DIR = '.composer-attribute-collector';
+
+    /**
+     * @var array<string, array<class-string, non-empty-string>>
+     *     Where _key_ is a directory and _value_ is an array where _key_ is a class and _value_ its path.
+     */
+    public array $mapByDir = [];
+    private string $cachePath;
+
+    public function __construct(
+        private string $basePath
+    ) {
+        $this->cachePath = $this->basePath . DIRECTORY_SEPARATOR . self::CACHE_DIR . DIRECTORY_SEPARATOR;
+
+        if (!is_dir($this->cachePath)) {
+            mkdir($this->cachePath);
+        }
+    }
+
+    /**
+     * @return array<class-string, non-empty-string>
+     *     Where _key_ is a class and _value_ its path.
+     */
+    public function getMap(): array
+    {
+        return array_merge(...array_values($this->mapByDir));
+    }
+
+    /**
+     * Iterate over all files in the given directory searching for classes
+     *
+     * @param string $path
+     *     The path to search in.
+     * @param non-empty-string|null $excluded
+     *     Regex that matches file paths to be excluded from the classmap
+     * @param 'classmap'|'psr-0'|'psr-4' $autoloadType
+     *     Optional autoload standard to use mapping rules with the namespace instead of purely doing a classmap
+     * @param string|null $namespace
+     *     Optional namespace prefix to filter by, only for psr-0/psr-4 autoloading
+     *
+     * @throws RuntimeException When the path is neither an existing file nor directory
+     */
+    public function scanPaths(
+        string $path,
+        string $excluded = null,
+        string $autoloadType = 'classmap',
+        ?string $namespace = null
+    ): void {
+        $this->mapByDir[$path] = $this->get(
+            $path,
+            static function () use ($path, $excluded, $autoloadType, $namespace): array {
+                $inner = new ClassMapGenerator();
+                $inner->avoidDuplicateScans();
+                $inner->scanPaths($path, $excluded, $autoloadType, $namespace);
+
+                return $inner->getClassMap()->getMap();
+            }
+        );
+    }
+
+    /**
+     * @param string $path
+     * @param Closure $scan
+     *
+     * @return array<class-string, non-empty-string>
+     *     Where _key_ is a class and _value_ its path.
+     */
+    private function get(string $path, Closure $scan): array
+    {
+        $key = $this->makeCacheKey($path);
+        $filename = $this->cachePath . $key;
+        $map = $this->cacheGet($filename, $path);
+
+        if ($map) {
+            return $map;
+        }
+
+        $map = $scan();
+
+        $this->cacheSet($filename, $map);
+
+        return $map;
+    }
+
+    private function makeCacheKey(string $path): string
+    {
+        $base = $this->basePath . DIRECTORY_SEPARATOR;
+
+        if (str_starts_with($path, $base)) {
+            $path = substr($path, strlen($base));
+        }
+
+        $key = preg_replace('/[^0-9A-Za-z]/', '-', $path);
+
+        assert(is_string($key));
+
+        return $key;
+    }
+
+    /**
+     * @param string $filename
+     * @param string $reference
+     *
+     * @return array<class-string, non-empty-string>|null
+     *     Where _key_ is a class and _value_ is its path.
+     */
+    private function cacheGet(string $filename, string $reference): ?array
+    {
+        if (!file_exists($filename)) {
+            return null;
+        }
+
+        $c = filemtime($filename);
+        $r = filemtime($reference);
+
+        if ($c === false || $r === false) {
+            return null;
+        }
+
+        if ($r > $c) {
+            return null;
+        }
+
+        $data = file_get_contents($filename);
+
+        if ($data) {
+            /** @phpstan-ignore-next-line */
+            return unserialize($data);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<class-string, non-empty-string> $map
+     *     Where _key_ is a class and _value_ is its path.
+     */
+    private function cacheSet(string $filename, array $map): void
+    {
+        file_put_contents($filename, serialize($map));
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -21,7 +21,6 @@ use olvlvl\ComposerAttributeCollector\Filter\PathFilter;
 use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionException;
-use ReflectionMethod;
 
 use function array_filter;
 use function array_merge;

--- a/src/TargetMethodRaw.php
+++ b/src/TargetMethodRaw.php
@@ -16,7 +16,7 @@ namespace olvlvl\ComposerAttributeCollector;
 final class TargetMethodRaw
 {
     /**
-     * @param array<string, mixed> $arguments
+     * @param array<int|string, mixed> $arguments
      * @param class-string $class
      * @param string $name
      */

--- a/tests/Acme/PSR4/SubscriberA.php
+++ b/tests/Acme/PSR4/SubscriberA.php
@@ -10,10 +10,12 @@
 namespace Acme\PSR4;
 
 use Acme\Attribute\Subscribe;
+use ReturnTypeWillChange;
 
 final class SubscriberA
 {
     #[Subscribe]
+    #[ReturnTypeWillChange]
     public function onEventA(EventA $event): void
     {
     }

--- a/tests/ClassAttributeCollectorTest.php
+++ b/tests/ClassAttributeCollectorTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace tests\olvlvl\ComposerAttributeCollector;
+
+use Acme\PSR4\CreateMenu;
+use Acme\PSR4\CreateMenuHandler;
+use Acme\PSR4\Presentation\ArticleController;
+use Acme\PSR4\SubscriberA;
+use Attribute;
+use Composer\IO\NullIO;
+use olvlvl\ComposerAttributeCollector\ClassAttributeCollector;
+use PHPUnit\Framework\TestCase;
+use ReflectionException;
+
+final class ClassAttributeCollectorTest extends TestCase
+{
+    private ClassAttributeCollector $sut;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sut = new ClassAttributeCollector(new NullIO());
+    }
+
+    /**
+     * @dataProvider provideCollectAttributes
+     *
+     * @param class-string $class
+     * @param array<int|string, mixed> $expected
+     *
+     * @throws ReflectionException
+     */
+    public function testCollectAttributes(string $class, array $expected): void
+    {
+        $actual = $this->sut->collectAttributes($class);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /** @phpstan-ignore-next-line */
+    public static function provideCollectAttributes(): array
+    {
+        return [
+
+            [
+                Attribute::class,
+                [
+                    [],
+                    [],
+                ]
+            ],
+
+            [
+                CreateMenu::class,
+                [
+                    [
+                        [ 'Acme\Attribute\Permission', [ 'is_admin' ] ],
+                        [ 'Acme\Attribute\Permission', [ 'can_create_menu' ] ],
+                    ],
+                    []
+                ]
+            ],
+
+            [
+                CreateMenuHandler::class,
+                [
+                    [
+                        [ 'Acme\Attribute\Handler', [ ] ]
+                    ],
+                    [],
+                ]
+            ],
+
+            [
+                ArticleController::class,
+                [
+                    [
+                        [ 'Acme\Attribute\Resource', [ "articles" ] ]
+                    ],
+                    [
+                        [ 'Acme\Attribute\Route', [ 'method' => 'GET', 'id' => 'articles:list', 'pattern' => "/articles" ], 'list' ],
+                        [ 'Acme\Attribute\Route', [ 'id' => 'articles:show', 'pattern' => "/articles/{id}", 'method' => 'GET' ], 'show' ],
+                    ],
+                ]
+            ],
+
+            [
+                SubscriberA::class,
+                [
+                    [],
+                    [
+                        [ 'Acme\Attribute\Subscribe', [], 'onEventA' ],
+                    ]
+                ]
+            ],
+
+        ];
+    }
+}

--- a/tests/ClassMapBuilderTest.php
+++ b/tests/ClassMapBuilderTest.php
@@ -9,7 +9,10 @@
 
 namespace tests\olvlvl\ComposerAttributeCollector;
 
+use Composer\IO\NullIO;
 use olvlvl\ComposerAttributeCollector\ClassMapBuilder;
+use olvlvl\ComposerAttributeCollector\FileDatastore;
+use olvlvl\ComposerAttributeCollector\MemoizeClassMapGenerator;
 use PHPUnit\Framework\TestCase;
 
 use function getcwd;
@@ -18,7 +21,13 @@ final class ClassMapBuilderTest extends TestCase
 {
     public function testBuildClassMap(): void
     {
-        $sut = new ClassMapBuilder();
+        $sut = new ClassMapBuilder(
+            new MemoizeClassMapGenerator(
+                new FileDatastore(get_cache_dir()),
+                new NullIO(),
+            )
+        );
+
         $classMap = $sut->buildClassMap([
             'psr-0' => [
             ],

--- a/tests/MemoizeClassMapGeneratorTest.php
+++ b/tests/MemoizeClassMapGeneratorTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace tests\olvlvl\ComposerAttributeCollector;
+
+use olvlvl\ComposerAttributeCollector\MemoizeClassMapGenerator;
+use PHPUnit\Framework\TestCase;
+
+use function file_put_contents;
+use function realpath;
+use function sleep;
+use function time;
+use function touch;
+use function var_dump;
+
+final class MemoizeClassMapGeneratorTest extends TestCase
+{
+    private const DIR = __DIR__ . '/sandbox-memoize-classmap/';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        clear_directory(self::DIR);
+    }
+
+    public function testMemoize(): void
+    {
+        $map = $this->map();
+        $this->assertEmpty($map);
+
+        self::write(
+            "a.php",
+            <<<PHP
+            <?php
+
+            namespace App;
+
+            #[\Acme\Attribute\Handler]
+            class A {
+            }
+            PHP
+        );
+
+        $map = $this->map();
+        $this->assertEquals([
+            'App\A' => self::DIR . 'a.php',
+        ], $map);
+
+        self::write(
+            "b.php",
+            <<<PHP
+            <?php
+
+            namespace App;
+
+            #[\Acme\Attribute\Handler]
+            class B {
+            }
+            PHP
+        );
+
+        // Because the modified time is a unix timestamp, we need the modified time to be the next second
+        touch(self::DIR, time() + 1);
+
+        $map = $this->map();
+        $this->assertEquals([
+            'App\A' => self::DIR . 'a.php',
+            'App\B' => self::DIR . 'b.php',
+        ], $map);
+    }
+
+    private static function write(string $name, string $data): void
+    {
+        file_put_contents(self::DIR . $name, $data);
+    }
+
+    /**
+     * @return array<class-string, string>
+     */
+    private static function map(): array
+    {
+        $generator = new MemoizeClassMapGenerator(__DIR__ . '/../.composer-attribute-collector');
+        $generator->scanPaths(self::DIR);
+
+        return $generator->getMap();
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,17 +5,27 @@ namespace tests\olvlvl\ComposerAttributeCollector;
 use DirectoryIterator;
 
 use function file_exists;
+use function is_string;
 use function realpath;
 use function str_starts_with;
 use function unlink;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
+function get_cache_dir(): string
+{
+    $dir = realpath(__DIR__ . '/../.composer-attribute-collector');
+
+    assert(is_string($dir));
+
+    return $dir;
+}
+
 /*
  * Clean up cache
  */
-
-function clear_directory(string $dir): void {
+function clear_directory(string $dir): void
+{
     $dir = realpath($dir);
 
     if ($dir && file_exists($dir)) {
@@ -36,5 +46,3 @@ function clear_directory(string $dir): void {
         }
     }
 }
-
-clear_directory(__DIR__ . '/../.composer-attribute-collector');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace tests\olvlvl\ComposerAttributeCollector;
+
+use DirectoryIterator;
+
+use function file_exists;
+use function realpath;
+use function str_starts_with;
+use function unlink;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+/*
+ * Clean up cache
+ */
+
+function clear_directory(string $dir): void {
+    $dir = realpath($dir);
+
+    if ($dir && file_exists($dir)) {
+        $di = new DirectoryIterator($dir);
+
+        foreach ($di as $file) {
+            /** @var DirectoryIterator $file */
+
+            if ($file->isDot()) {
+                continue;
+            }
+
+            if (str_starts_with($file->getFilename(), '.')) {
+                continue;
+            }
+
+            unlink($file->getPathname());
+        }
+    }
+}
+
+clear_directory(__DIR__ . '/../.composer-attribute-collector');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,8 +4,9 @@ namespace tests\olvlvl\ComposerAttributeCollector;
 
 use DirectoryIterator;
 
+use function dirname;
 use function file_exists;
-use function is_string;
+use function is_dir;
 use function realpath;
 use function str_starts_with;
 use function unlink;
@@ -14,9 +15,11 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 function get_cache_dir(): string
 {
-    $dir = realpath(__DIR__ . '/../.composer-attribute-collector');
+    $dir = dirname(__DIR__) . '/.composer-attribute-collector';
 
-    assert(is_string($dir));
+    if (!is_dir($dir)) {
+        mkdir($dir);
+    }
 
     return $dir;
 }

--- a/tests/sandbox-memoize-classmap/.gitignore
+++ b/tests/sandbox-memoize-classmap/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
This PR introduces caching in the following steps:

- Building class map
- Filtering class map
- Collecting attributes from classes

## Comparing branches

Here are the numbers for the [Symfony use case](https://github.com/olvlvl/composer-attribute-collector-usecase-symfony).

`main`:

```
Generating attributes file: built autoloads in 0.641 ms
Generating attributes file: built class map in 3981.052 ms
Generating attributes file: filtered class map in 155.308 ms
Generating attributes file: collected attributes in 0.872 ms
Generating attributes file: rendered code in 0.038 ms
Generated attributes file in 4138.721 ms
```

`cache` (cold):

```
Generating attributes file: built autoloads in 0.569 ms
Generating attributes file: built class map in 4425.002 ms
Generating attributes file: filtered class map in 152.405 ms
Generating attributes file: collected attributes in 4.116 ms
Generating attributes file: rendered code in 0.042 ms
Generated attributes file in 4586.312 ms
```

`cache` (warm):

```
Generating attributes file: built autoloads in 0.714 ms
Generating attributes file: built class map in 6.068 ms
Generating attributes file: filtered class map in 24.393 ms
Generating attributes file: collected attributes in 2.151 ms
Generating attributes file: rendered code in 0.033 ms
Generated attributes file in 37.974 ms
```