### PR TITLE
Add filterTargetClasses and filterTargetMethods

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,31 @@
 # Migration
 
+## v1.1 to v1.2
+
+### New Requirements
+
+None
+
+### New features
+
+- [#11](https://github.com/olvlvl/composer-attribute-collector/pull/11) Attribute instantiation errors are decorated to help find origin (@withinboredom @olvlvl)
+- [#12](https://github.com/olvlvl/composer-attribute-collector/pull/12) `Attributes::filterTargetClasses()` can filter target classes using a predicate (@olvlvl)
+- [#12](https://github.com/olvlvl/composer-attribute-collector/pull/12) `Attributes::filterTargetMethods()` can filter target methods using a predicate (@olvlvl)
+
+### Backward Incompatible Changes
+
+None
+
+### Deprecated Features
+
+None
+
+### Other Changes
+
+None
+
+
+
 ## v1.0 to v1.1
 
 ### New Requirements

--- a/README.md
+++ b/README.md
@@ -39,15 +39,22 @@ require_once 'vendor/attributes.php'; // <-- the file created by the plugin
 foreach (Attributes::findTargetClasses(AsMessageHandler::class) as $target) {
     // $target->attribute is an instance of the specified attribute
     // with the actual data.
-    var_dump($target->name, $target->attribute);
+    var_dump($target->attribute, $target->name);
 }
 
 // Find the target methods of the Route attribute.
 foreach (Attributes::findTargetMethods(Route::class) as $target) {
-    var_dump($target->class, $target->name, $target->attribute);
+    var_dump($target->attribute, $target->class, $target->name);
 }
 
-// Find attributes for the ArticleController class.
+// Filter target methods using a predicate.
+foreach (Attributes::filterTargetMethods(
+    fn($attribute) => is_a($attribute, Route::class, true)
+) as $target) {
+    var_dump($target->attribute, $target->class, $target->name);
+}
+
+// Find class and method attributes for the ArticleController class.
 $attributes = Attributes::forClass(ArticleController::class);
 
 var_dump($attributes->classAttributes);
@@ -287,6 +294,41 @@ final class IsAdmin implements Voter
 {
     // ...
 }
+```
+
+## Using Attributes
+
+### Filtering target methods
+
+`filterTargetMethods()` can filter target methods using a predicate. This can be helpful when a number of attributes extend another one, and you are interested in collecting any instance of that attribute.
+
+Let's say we have a `Route` attribute extended by `Get`, `Post`, `Put`…
+
+```php
+<?php
+
+use olvlvl\ComposerAttributeCollector\Attributes;
+
+/** @var TargetMethod<Route>[] $target_methods */
+$target_methods = [
+    ...Attributes::findTargetMethods(Get::class),
+    ...Attributes::findTargetMethods(Head::class),
+    ...Attributes::findTargetMethods(Post::class),
+    ...Attributes::findTargetMethods(Put::class),
+    ...Attributes::findTargetMethods(Delete::class),
+    ...Attributes::findTargetMethods(Connect::class),
+    ...Attributes::findTargetMethods(Options::class),
+    ...Attributes::findTargetMethods(Trace::class),
+    ...Attributes::findTargetMethods(Patch::class),
+    ...Attributes::findTargetMethods(Route::class),
+];
+
+// Can be replaced by:
+
+/** @var TargetMethod<Route>[] $target_methods */
+$target_methods = Attributes::filterTargetMethods(
+    fn($attribute) => is_a($attribute, Route::class, true)
+);
 ```
 
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,10 @@
         "psr-4": {
             "tests\\olvlvl\\ComposerAttributeCollector\\": "tests",
             "Acme\\": "tests/Acme"
-        }
+        },
+        "classmap": [
+            "tests/Acme/ClassMap"
+        ]
     },
     "config": {
         "sort-packages": true

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -55,6 +55,26 @@ final class Attributes
     }
 
     /**
+     * @param callable(class-string $attribute, class-string $class):bool $predicate
+     *
+     * @return array<TargetClass<object>>
+     */
+    public static function filterTargetClasses(callable $predicate): array
+    {
+        return self::getCollection()->filterTargetClasses($predicate);
+    }
+
+    /**
+     * @param callable(class-string $attribute, class-string $class, string $method):bool $predicate
+     *
+     * @return array<TargetMethod<object>>
+     */
+    public static function filterTargetMethods(callable $predicate): array
+    {
+        return self::getCollection()->filterTargetMethods($predicate);
+    }
+
+    /**
      * @var array<class-string, ForClass>
      */
     private static array $forClassCache = [];

--- a/tests/Acme/Attribute/Get.php
+++ b/tests/Acme/Attribute/Get.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Acme\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Get extends Route
+{
+    public function __construct(
+        string $pattern = '',
+        ?string $id = null
+    ) {
+        parent::__construct($pattern, 'GET', $id);
+    }
+}

--- a/tests/Acme/Attribute/Post.php
+++ b/tests/Acme/Attribute/Post.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Acme\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Post extends Route
+{
+    public function __construct(
+        string $pattern = '',
+        ?string $id = null
+    ) {
+        parent::__construct($pattern, 'POST', $id);
+    }
+}

--- a/tests/Acme/Attribute/Route.php
+++ b/tests/Acme/Attribute/Route.php
@@ -11,8 +11,8 @@ namespace Acme\Attribute;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_METHOD)]
-final class Route
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
+class Route
 {
     /**
      * @param string|string[] $method

--- a/tests/Acme/ClassMap/controllers.php
+++ b/tests/Acme/ClassMap/controllers.php
@@ -9,29 +9,32 @@
 
 namespace Acme\Presentation;
 
+use Acme\Attribute\Get;
 use Acme\Attribute\Route;
 
+#[Route('/images')]
 final class ImageController
 {
-    #[Route("/images")]
+    #[Get]
     protected function list(): void
     {
     }
 
-    #[Route("/images/{id}")]
+    #[Get("/{id}")]
     private function show(int $id): void
     {
     }
 }
 
+#[Route('/files')]
 final class FileController
 {
-    #[Route("/files")]
+    #[Get]
     public function list(): void
     {
     }
 
-    #[Route("/files/{id}")]
+    #[Get('/{id}')]
     public function show(int $id): void
     {
     }


### PR DESCRIPTION
The filter methods enable filtering target classes and target methods using a predicate.

Let's say we have a `Route` attribute extended by `Get`, `Post`, `Put`…

```php
/** @var TargetMethod<Route>[] $target_methods */
$target_methods = [
    ...Attributes::findTargetMethods(Get::class),
    ...Attributes::findTargetMethods(Head::class),
    ...Attributes::findTargetMethods(Post::class),
    ...Attributes::findTargetMethods(Put::class),
    ...Attributes::findTargetMethods(Delete::class),
    ...Attributes::findTargetMethods(Connect::class),
    ...Attributes::findTargetMethods(Options::class),
    ...Attributes::findTargetMethods(Trace::class),
    ...Attributes::findTargetMethods(Patch::class),
    ...Attributes::findTargetMethods(Route::class),
];
```

… can be replaced by:

```php
/** @var TargetMethod<Route>[] $target_methods */
$target_methods = Attributes::filterTargetMethods(
    fn($attribute) => is_a($attribute, Route::class, true)
);
```