### PR TITLE
ignore-paths are relative to the composer.json file

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
 # Migration
 
-## v1.2 to v1.3
+## v1.2 to v2.0
 
 ### New Requirements
 
@@ -12,7 +12,7 @@ None
 
 ### Backward Incompatible Changes
 
-None
+- The value of `ignore-paths` is no longer a pattern, it is now relative to the `composer.json` file. The `{vendor}` placeholder can be used as a placeholder for the absolute path to the vendor directory.
 
 ### Deprecated Features
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,9 @@ You can require the attributes file as shown in the usage example, but it's pref
 
 composer-attribute-collector inspects files that participate in the autoload process. This can cause
 issues with files that have side effects. For instance, `symfony/cache` is known to cause issues, so
-we're excluding paths matching `symfony/cache/Traits` from inspection. Additional paths can be
-specified using the `extra` section of `composer.json`:
+we're excluding paths matching `{vendor}/symfony/cache/Traits` from inspection. Additional paths can
+be specified using the `extra` section of `composer.json`. The specified paths are relative to the
+`composer.json` file, and the `{vendor}` placeholder is replaced with the path to the vendor folder.
 
 ```json
 {

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace olvlvl\ComposerAttributeCollector;
+
+use Composer\Factory;
+use Composer\PartialComposer;
+use InvalidArgumentException;
+use RuntimeException;
+
+use function array_merge;
+use function dirname;
+use function is_string;
+use function realpath;
+use function str_ends_with;
+use function str_starts_with;
+use function strlen;
+
+use const DIRECTORY_SEPARATOR;
+
+/**
+ * @readonly
+ * @internal
+ */
+final class Config
+{
+    public const EXTRA = 'composer-attribute-collector';
+    public const EXTRA_IGNORE_PATHS = 'ignore-paths';
+
+    public const BUILTIN_IGNORE_PATHS = [
+
+        // https://github.com/olvlvl/composer-attribute-collector/issues/4
+        "{vendor}/symfony/cache/Traits"
+
+    ];
+
+    /**
+     * If a path starts with this placeholder, it is replaced with the absolute path to the vendor directory.
+     */
+    public const VENDOR_PLACEHOLDER = '{vendor}';
+
+    public static function from(PartialComposer $composer): self
+    {
+        $vendorDir = $composer->getConfig()->get('vendor-dir');
+
+        if (!is_string($vendorDir) || !$vendorDir) {
+            throw new RuntimeException("Unable to determine vendor directory");
+        }
+
+        $composerFile = Factory::getComposerFile();
+        $rootDir = realpath(dirname($composerFile));
+
+        if (!$rootDir) {
+            throw new RuntimeException("Unable to determine root directory");
+        }
+
+        $rootDir .= DIRECTORY_SEPARATOR;
+
+        /** @var array{ ignore-paths?: non-empty-string[] } $extra */
+        $extra = $composer->getPackage()->getExtra()[self::EXTRA] ?? [];
+
+        $ignorePaths = self::expandPaths(
+            array_merge($extra[self::EXTRA_IGNORE_PATHS] ?? [], self::BUILTIN_IGNORE_PATHS),
+            $vendorDir,
+            $rootDir
+        );
+
+        return new self(
+            attributesFile: "$vendorDir/attributes.php",
+            ignorePaths: $ignorePaths,
+        );
+    }
+
+    /**
+     * @param non-empty-string $attributesFile
+     *     Absolute path to the `attributes.php` file.
+     * @param string[] $ignorePaths
+     *     Paths that should be ignored for attributes collection.
+     */
+    public function __construct(
+        public string $attributesFile,
+        public array $ignorePaths,
+    ) {
+    }
+
+    /**
+     * @param non-empty-string[] $paths
+     * @param non-empty-string $vendorDir
+     * @param non-empty-string $rootDir
+     *
+     * @return non-empty-string[]
+     */
+    private static function expandPaths(array $paths, string $vendorDir, string $rootDir): array
+    {
+        if (str_ends_with($vendorDir, DIRECTORY_SEPARATOR)) {
+            throw new InvalidArgumentException("vendorDir must not end with a directory separator, given: $vendorDir");
+        }
+
+        if (!str_ends_with($rootDir, DIRECTORY_SEPARATOR)) {
+            throw new InvalidArgumentException("rootDir must end with a directory separator, given: $rootDir");
+        }
+
+        $expanded = [];
+
+        foreach ($paths as $path) {
+            if (str_starts_with($path, self::VENDOR_PLACEHOLDER)) {
+                $path = $vendorDir . substr($path, strlen(self::VENDOR_PLACEHOLDER));
+            } else {
+                $path = $rootDir . $path;
+            }
+
+            $expanded[] = $path;
+        }
+
+        return $expanded;
+    }
+}

--- a/src/Filter/PathFilter.php
+++ b/src/Filter/PathFilter.php
@@ -12,8 +12,11 @@ namespace olvlvl\ComposerAttributeCollector\Filter;
 use Composer\IO\IOInterface;
 use olvlvl\ComposerAttributeCollector\Filter;
 
-use function str_contains;
+use function str_starts_with;
 
+/**
+ * @internal
+ */
 final class PathFilter implements Filter
 {
     /**
@@ -27,7 +30,7 @@ final class PathFilter implements Filter
     public function filter(string $filepath, string $class, IOInterface $io): bool
     {
         foreach ($this->matches as $match) {
-            if (str_contains($filepath, $match)) {
+            if (str_starts_with($filepath, $match)) {
                 $io->debug("Discarding '$class' because its path matches '$match'");
 
                 return false;

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace tests\olvlvl\ComposerAttributeCollector;
+
+use Composer\Package\RootPackageInterface;
+use Composer\PartialComposer;
+use olvlvl\ComposerAttributeCollector\Config;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use function assert;
+use function getcwd;
+use function is_string;
+
+final class ConfigTest extends TestCase
+{
+    public function testFrom(): void
+    {
+        $extra = [
+            Config::EXTRA => [
+                Config::EXTRA_IGNORE_PATHS => [
+                    '{vendor}/vendor1/package1',
+                    'tests/Acme/PSR4/IncompatibleSignature.php'
+                ]
+            ]
+        ];
+
+        $package = $this->getMockBuilder(RootPackageInterface::class)->getMock();
+        $package
+            ->method('getExtra')
+            ->willReturn($extra);
+
+        $cwd = getcwd();
+        assert(is_string($cwd));
+        $config = $this->getMockBuilder(\Composer\Config::class)->getMock();
+        $config
+            ->method('get')
+            ->with('vendor-dir')
+            ->willReturn("$cwd/vendor");
+
+        $composer = new PartialComposer();
+        $composer->setConfig($config);
+        $composer->setPackage($package);
+
+        $expected = new Config(
+            attributesFile: "$cwd/vendor/attributes.php",
+            ignorePaths: [
+                "$cwd/vendor/vendor1/package1",
+                "$cwd/tests/Acme/PSR4/IncompatibleSignature.php",
+                "$cwd/vendor/symfony/cache/Traits",
+            ]
+        );
+
+        $actual = Config::from($composer);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testFromFailsOnMissingVendorDir(): void
+    {
+        $config = $this->getMockBuilder(\Composer\Config::class)->getMock();
+        $config
+            ->method('get')
+            ->with('vendor-dir')
+            ->willReturn("");
+
+        $composer = new PartialComposer();
+        $composer->setConfig($config);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("Unable to determine vendor directory");
+
+        Config::from($composer);
+    }
+}

--- a/tests/Filter/PathFilterTest.php
+++ b/tests/Filter/PathFilterTest.php
@@ -22,12 +22,14 @@ final class PathFilterTest extends TestCase
         parent::setUp();
 
         $this->filter = new PathFilter([
-            "symfony/cache/Traits"
+            "/absolute/path/to/symfony/cache/Traits"
         ]);
     }
 
     /**
      * @dataProvider provideFilter
+     *
+     * @param class-string $class
      */
     public function testFilter(string $filepath, string $class, bool $expected): void
     {
@@ -49,12 +51,17 @@ final class PathFilterTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    /**
+     * @return array<array{ non-empty-string, string, bool }>
+     */
     public function provideFilter(): array
     {
         return [
 
-            [ "vendor/symfony/cache/Traits/RedisCluster5Proxy.php", "RedisCluster5Proxy", false ],
-            [ "vendor/symfony/routing/Route.php", "Route", true ],
+            [ "/absolute/path/to/symfony/cache/Traits/RedisCluster5Proxy.php", "RedisCluster5Proxy", false ],
+            [ "some/prefix/absolute/path/to/symfony/cache/Traits/RedisCluster5Proxy.php", "RedisCluster5Proxy", true ],
+            [ "symfony/cache/Traits/RedisCluster5Proxy.php", "RedisCluster5Proxy", true ],
+            [ "/absolute/path/to/symfony/routing/Route.php", "Route", true ],
 
         ];
     }

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -25,15 +25,18 @@ use Acme\Attribute\Subscribe;
 use Acme\PSR4\Presentation\ArticleController;
 use Composer\Composer;
 use Composer\IO\NullIO;
-use Composer\Package\RootPackageInterface;
 use olvlvl\ComposerAttributeCollector\Attributes;
 use olvlvl\ComposerAttributeCollector\AutoloadsBuilder;
+use olvlvl\ComposerAttributeCollector\Config;
 use olvlvl\ComposerAttributeCollector\Plugin;
 use olvlvl\ComposerAttributeCollector\TargetClass;
 use olvlvl\ComposerAttributeCollector\TargetMethod;
 use olvlvl\ComposerAttributeCollector\TargetProperty;
 use PHPUnit\Framework\TestCase;
+use ReflectionException;
 
+use function getcwd;
+use function is_string;
 use function str_contains;
 use function usort;
 
@@ -41,6 +44,9 @@ final class PluginTest extends TestCase
 {
     private static bool $initialized = false;
 
+    /**
+     * @throws ReflectionException
+     */
     protected function setUp(): void
     {
         parent::setUp();
@@ -49,23 +55,7 @@ final class PluginTest extends TestCase
             return;
         }
 
-        $extra = [
-            Plugin::EXTRA => [
-                Plugin::EXTRA_IGNORE_PATHS => [
-                    'IncompatibleSignature'
-                ]
-            ]
-        ];
-
-        $package = $this->getMockBuilder(RootPackageInterface::class)->getMock();
-        $package
-            ->method('getExtra')
-            ->willReturn($extra);
-
         $composer = $this->getMockBuilder(Composer::class)->getMock();
-        $composer
-            ->method('getPackage')
-            ->willReturn($package);
 
         $autoloadsBuilder = $this->getMockBuilder(AutoloadsBuilder::class)->getMock();
         $autoloadsBuilder
@@ -86,12 +76,21 @@ final class PluginTest extends TestCase
                 ]
             );
 
+        $cwd = getcwd();
+        assert(is_string($cwd));
         $filepath = __DIR__ . '/sandbox/attributes.php';
+
+        $config = new Config(
+            $filepath,
+            [
+                "$cwd/tests/Acme/PSR4/IncompatibleSignature.php"
+            ]
+        );
 
         Plugin::dump(
             $composer,
+            $config,
             new NullIO(),
-            $filepath,
             $autoloadsBuilder
         );
 


### PR DESCRIPTION
Paths defined with `ignore-paths` are now relative to the composer.json file.

It's a breaking change and requires a major update.