### PR TITLE
Recover unserialize errors (Fix #19)

### DIFF
--- a/src/FileDatastore.php
+++ b/src/FileDatastore.php
@@ -2,12 +2,17 @@
 
 namespace olvlvl\ComposerAttributeCollector;
 
+use Composer\IO\IOInterface;
+
 use function file_exists;
 use function file_get_contents;
 use function file_put_contents;
+use function is_array;
 use function is_dir;
 use function mkdir;
+use function restore_error_handler;
 use function serialize;
+use function set_error_handler;
 use function unserialize;
 
 use const DIRECTORY_SEPARATOR;
@@ -21,7 +26,8 @@ final class FileDatastore implements Datastore
      * @param non-empty-string $dir
      */
     public function __construct(
-        private string $dir
+        private string $dir,
+        private IOInterface $io,
     ) {
         assert($dir !== '');
 
@@ -38,8 +44,7 @@ final class FileDatastore implements Datastore
             return [];
         }
 
-        /** @phpstan-ignore-next-line */
-        return unserialize(file_get_contents($filename));
+        return self::safeGet($filename);
     }
 
     public function set(string $key, array $data): void
@@ -47,5 +52,37 @@ final class FileDatastore implements Datastore
         $filename = $this->dir . DIRECTORY_SEPARATOR . $key;
 
         file_put_contents($filename, serialize($data));
+    }
+
+    /**
+     * @return mixed[]
+     */
+    private function safeGet(string $filename): array
+    {
+        $str = file_get_contents($filename);
+
+        if ($str === false) {
+            return [];
+        }
+
+        $errored = false;
+
+        set_error_handler(function (int $errno, string $errstr) use (&$errored, $filename): bool {
+            $errored = true;
+
+            $this->io->warning("Unable to unserialize cache item $filename: $errstr");
+
+            return true;
+        });
+
+        $ar = unserialize($str);
+
+        restore_error_handler();
+
+        if ($errored || !is_array($ar)) {
+            return [];
+        }
+
+        return $ar;
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -100,7 +100,7 @@ final class Plugin implements PluginInterface, EventSubscriberInterface
         AutoloadsBuilder $autoloadsBuilder = null,
         ClassMapBuilder $classMapBuilder = null
     ): void {
-        $datastore = self::buildDefaultDatastore();
+        $datastore = self::buildDefaultDatastore($io);
         $autoloadsBuilder ??= new AutoloadsBuilder();
         $classMapGenerator = new MemoizeClassMapGenerator($datastore, $io);
         $classMapBuilder ??= new ClassMapBuilder($classMapGenerator);
@@ -141,13 +141,13 @@ final class Plugin implements PluginInterface, EventSubscriberInterface
         file_put_contents($filepath, $code);
     }
 
-    private static function buildDefaultDatastore(): Datastore
+    private static function buildDefaultDatastore(IOInterface $io): Datastore
     {
         $basePath = Platform::getCwd();
 
         assert($basePath !== '');
 
-        return new FileDatastore($basePath . DIRECTORY_SEPARATOR . self::CACHE_DIR);
+        return new FileDatastore($basePath . DIRECTORY_SEPARATOR . self::CACHE_DIR, $io);
     }
 
     private static function renderElapsedTime(float $start): string

--- a/tests/ClassMapBuilderTest.php
+++ b/tests/ClassMapBuilderTest.php
@@ -21,10 +21,11 @@ final class ClassMapBuilderTest extends TestCase
 {
     public function testBuildClassMap(): void
     {
+        $io = new NullIO();
         $sut = new ClassMapBuilder(
             new MemoizeClassMapGenerator(
-                new FileDatastore(get_cache_dir()),
-                new NullIO(),
+                new FileDatastore(get_cache_dir(), $io),
+                $io,
             )
         );
 

--- a/tests/FileDatastoreTest.php
+++ b/tests/FileDatastoreTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace tests\olvlvl\ComposerAttributeCollector;
+
+use Composer\IO\IOInterface;
+use olvlvl\ComposerAttributeCollector\FileDatastore;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+use function file_put_contents;
+
+final class FileDatastoreTest extends TestCase
+{
+    private const DIR = __DIR__ . '/sandbox/';
+    private const KEY = 'file-datastore';
+
+    /**
+     * @var MockObject&IOInterface
+     */
+    private MockObject|IOInterface $io;
+    private FileDatastore $sut;
+
+    protected function setUp(): void
+    {
+        $this->io = $this->createMock(IOInterface::class);
+        $this->sut = new FileDatastore(self::DIR, $this->io);
+
+        parent::setUp();
+    }
+
+    public function testValidUnserialize(): void
+    {
+        $str = 'a:3:{i:0;i:2;i:1;i:3;i:2;i:5;}';
+        $expected = [ 2, 3, 5 ];
+        $this->io
+            ->expects($this->never())
+            ->method('warning')
+            ->withAnyParameters();
+
+        self::write($str);
+
+        $actual = $this->sut->get(self::KEY);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testUnserializeWithMissingEnum(): void
+    {
+        $str = 'a:1:{i:0;E:12:"Priority:TOP";}';
+        $expected = [];
+        $this->io
+            ->expects($this->atLeastOnce()) // PHP 8.2 also complains that the class 'Priority' is not found
+            ->method('warning')
+            ->with($this->stringStartsWith("Unable to unserialize cache item"));
+
+        self::write($str);
+
+        $actual = $this->sut->get(self::KEY);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testUnserializeWithMissingClass(): void
+    {
+        $this->markTestSkipped("Don't know how to catch missing classes yet");
+
+        $str = 'a:1:{i:0;O:8:"Priority":1:{s:8:"priority";i:1;}}';
+        $expected = [];
+        $this->io
+            ->expects($this->atLeastOnce())
+            ->method('warning')
+            ->with($this->stringStartsWith("Unable to unserialize cache item"));
+
+        self::write($str);
+
+        $actual = $this->sut->get(self::KEY);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    private static function write(string $str): void
+    {
+        file_put_contents(self::DIR . self::KEY, $str);
+    }
+}

--- a/tests/MemoizeClassMapGeneratorTest.php
+++ b/tests/MemoizeClassMapGeneratorTest.php
@@ -98,9 +98,10 @@ final class MemoizeClassMapGeneratorTest extends TestCase
      */
     private static function map(string $path): array
     {
+        $io = new NullIO();
         $generator = new MemoizeClassMapGenerator(
-            new FileDatastore(get_cache_dir()),
-            new NullIO(),
+            new FileDatastore(get_cache_dir(), $io),
+            $io,
         );
 
         $generator->scanPaths($path);


### PR DESCRIPTION
Recover for unserialize errors, e.g. a missing enum.

https://github.com/olvlvl/composer-attribute-collector/issues/19