### PR TITLE
Ignore incomplete cache entries

### DIFF
--- a/src/ClassAttributeCollector.php
+++ b/src/ClassAttributeCollector.php
@@ -20,22 +20,15 @@ class ClassAttributeCollector
 
     /**
      * @param class-string $class
-     *
-     * @return array{
-     *     array<TransientTargetClass>,
-     *     array<TransientTargetMethod>,
-     *     array<TransientTargetProperty>,
-     * }
-     *     Where `0` is an array of class attributes, `1` is an array of method attributes,
-     *     and `2` is an array of property attributes.
+     * @return TransientClass
      * @throws ReflectionException
      */
-    public function collectAttributes(string $class): array
+    public function collectAttributes(string $class): TransientClass
     {
         $classReflection = new ReflectionClass($class);
 
         if (self::isAttribute($classReflection)) {
-            return [ [], [], [] ];
+            return new TransientClass([], [], []);
         }
 
         $classAttributes = [];
@@ -96,7 +89,11 @@ class ClassAttributeCollector
             }
         }
 
-        return [ $classAttributes, $methodAttributes, $propertyAttributes ];
+        return new TransientClass(
+            classAttributes: $classAttributes,
+            methodAttributes: $methodAttributes,
+            propertyAttributes: $propertyAttributes,
+        );
     }
 
     /**

--- a/src/Datastore.php
+++ b/src/Datastore.php
@@ -8,12 +8,27 @@ namespace olvlvl\ComposerAttributeCollector;
 interface Datastore
 {
     /**
-     * @return array<int|string, mixed>
+     * @return array<class-string, array{
+     *     int,
+     *     array<TransientTargetClass>,
+     *     array<TransientTargetMethod>,
+     *     array<TransientTargetProperty>,
+     * }>
+     *     Where _key_ is a class and _value is an array where:
+     *     - `0` is a timestamp
+     *     - `1` is an array of class attributes
+     *     - `2` is an array of method attributes
+     *     - `3` is an array of property attributes
      */
     public function get(string $key): array;
 
     /**
-     * @param array<int|string, mixed> $data
+     * @param array<class-string, array{
+     *     int,
+     *     array<TransientTargetClass>,
+     *     array<TransientTargetMethod>,
+     *     array<TransientTargetProperty>,
+     * }> $data
      */
     public function set(string $key, array $data): void;
 }

--- a/src/TransientClass.php
+++ b/src/TransientClass.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace olvlvl\ComposerAttributeCollector;
+
+final class TransientClass
+{
+    /**
+     * @param array<TransientTargetClass> $classAttributes
+     * @param array<TransientTargetMethod> $methodAttributes
+     * @param array<TransientTargetProperty> $propertyAttributes
+     */
+    public function __construct(
+        public array $classAttributes,
+        public array $methodAttributes,
+        public array $propertyAttributes,
+    )
+    {
+    }
+}

--- a/tests/ClassAttributeCollectorTest.php
+++ b/tests/ClassAttributeCollectorTest.php
@@ -31,15 +31,24 @@ final class ClassAttributeCollectorTest extends TestCase
      * @dataProvider provideCollectAttributes
      *
      * @param class-string $class
-     * @param array<int|string, mixed> $expected
+     * @param array<TransientTargetClass> $expectedClassAttributes
+     * @param array<TransientTargetMethod> $expectedMethodAttributes
+     * @param array<TransientTargetProperty> $expectedPropertyAttributes
      *
      * @throws ReflectionException
      */
-    public function testCollectAttributes(string $class, array $expected): void
+    public function testCollectAttributes(
+        string $class,
+        array $expectedClassAttributes,
+        array $expectedMethodAttributes,
+        array $expectedPropertyAttributes,
+    ): void
     {
         $actual = $this->sut->collectAttributes($class);
 
-        $this->assertEquals($expected, $actual);
+        $this->assertEquals($expectedClassAttributes, $actual->classAttributes);
+        $this->assertEquals($expectedMethodAttributes, $actual->methodAttributes);
+        $this->assertEquals($expectedPropertyAttributes, $actual->propertyAttributes);
     }
 
     /** @phpstan-ignore-next-line */
@@ -49,86 +58,74 @@ final class ClassAttributeCollectorTest extends TestCase
 
             [
                 Attribute::class,
-                [
-                    [],
-                    [],
-                    [],
-                ]
+                [],
+                [],
+                [],
             ],
 
             [
                 CreateMenu::class,
                 [
-                    [
-                        new TransientTargetClass('Acme\Attribute\Permission', [ 'is_admin' ]),
-                        new TransientTargetClass('Acme\Attribute\Permission', [ 'can_create_menu' ]),
-                    ],
-                    [],
-                    [],
-                ]
+                    new TransientTargetClass('Acme\Attribute\Permission', [ 'is_admin' ]),
+                    new TransientTargetClass('Acme\Attribute\Permission', [ 'can_create_menu' ]),
+                ],
+                [],
+                [],
             ],
 
             [
                 CreateMenuHandler::class,
                 [
-                    [
-                        new TransientTargetClass('Acme\Attribute\Handler', []),
-                    ],
-                    [],
-                    [],
-                ]
+                    new TransientTargetClass('Acme\Attribute\Handler', []),
+                ],
+                [],
+                [],
             ],
 
             [
                 ArticleController::class,
                 [
-                    [
-                        new TransientTargetClass('Acme\Attribute\Resource', [ "articles" ]),
-                    ],
-                    [
-                        new TransientTargetMethod(
-                            'Acme\Attribute\Route',
-                            [ 'method' => 'GET', 'id' => 'articles:list', 'pattern' => "/articles" ],
-                            'list',
-                        ),
-                        new TransientTargetMethod(
-                            'Acme\Attribute\Route',
-                            [ 'id' => 'articles:show', 'pattern' => "/articles/{id}", 'method' => 'GET' ],
-                            'show',
-                        ),
-                    ],
-                    [],
-                ]
+                    new TransientTargetClass('Acme\Attribute\Resource', [ "articles" ]),
+                ],
+                [
+                    new TransientTargetMethod(
+                        'Acme\Attribute\Route',
+                        [ 'method' => 'GET', 'id' => 'articles:list', 'pattern' => "/articles" ],
+                        'list',
+                    ),
+                    new TransientTargetMethod(
+                        'Acme\Attribute\Route',
+                        [ 'id' => 'articles:show', 'pattern' => "/articles/{id}", 'method' => 'GET' ],
+                        'show',
+                    ),
+                ],
+                [],
             ],
 
             [
                 SubscriberA::class,
+                [],
                 [
-                    [],
-                    [
-                        new TransientTargetMethod('Acme\Attribute\Subscribe', [], 'onEventA'),
-                    ],
-                    [],
-                ]
+                    new TransientTargetMethod('Acme\Attribute\Subscribe', [], 'onEventA'),
+                ],
+                [],
             ],
 
             [
                 Article::class,
                 [
-                    [
-                        new TransientTargetClass('Acme\Attribute\ActiveRecord\Index', [ 'active' ]),
-                    ],
-                    [
-                    ],
-                    [
-                        new TransientTargetProperty('Acme\Attribute\ActiveRecord\Id', [], 'id'),
-                        new TransientTargetProperty('Acme\Attribute\ActiveRecord\Serial', [], 'id'),
-                        new TransientTargetProperty('Acme\Attribute\ActiveRecord\Varchar', [ 80 ], 'title'),
-                        new TransientTargetProperty('Acme\Attribute\ActiveRecord\Varchar', [ 80, 'unique' => true ], 'slug'),
-                        new TransientTargetProperty('Acme\Attribute\ActiveRecord\Text', [], 'body'),
-                        new TransientTargetProperty('Acme\Attribute\ActiveRecord\Boolean', [], 'active'),
-                    ],
-                ]
+                    new TransientTargetClass('Acme\Attribute\ActiveRecord\Index', [ 'active' ]),
+                ],
+                [
+                ],
+                [
+                    new TransientTargetProperty('Acme\Attribute\ActiveRecord\Id', [], 'id'),
+                    new TransientTargetProperty('Acme\Attribute\ActiveRecord\Serial', [], 'id'),
+                    new TransientTargetProperty('Acme\Attribute\ActiveRecord\Varchar', [ 80 ], 'title'),
+                    new TransientTargetProperty('Acme\Attribute\ActiveRecord\Varchar', [ 80, 'unique' => true ], 'slug'),
+                    new TransientTargetProperty('Acme\Attribute\ActiveRecord\Text', [], 'body'),
+                    new TransientTargetProperty('Acme\Attribute\ActiveRecord\Boolean', [], 'active'),
+                ],
             ],
 
         ];


### PR DESCRIPTION
This should resolve the issue with cache during upgrade ~1.2 -> ^1.3

```
  - Upgrading olvlvl/composer-attribute-collector (v1.2.2 => dev-ignore-unserialize-errors a27b061): Extracting archive
Generating autoload files
Generating attributes file

In MemoizeAttributeCollector.php line 62:
                         
  Undefined array key 3 
```

It also moved the call to datastore::get from memoize collector contructor to its action method, because it caused sideeffect on construction site.