### PR TITLE
Support nested attributes introduced in PHP 8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # CHANGELOG
 
+## v2.2.0
+
+### New Requirements
+
+None
+
+### New features
+
+None
+
+### Deprecated Features
+
+None
+
+### Backward Incompatible Changes
+
+None
+
+### Other Changes
+
+- [#36](https://github.com/olvlvl/composer-attribute-collector/pull/36) Attribute arguments are now serialized to support [nested attributes introduced in PHP 8.1](https://wiki.php.net/rfc/new_in_initializers).
+
+
+
 ## v2.1.0
 
 ### New Requirements

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -13,18 +13,18 @@ use function array_map;
 final class Collection
 {
     /**
-     * @param array<class-string, array<array{ mixed[], class-string }>> $targetClasses
+     * @param array<class-string, array<array{ string, class-string }>> $targetClasses
      *     Where _key_ is an attribute class and _value_ an array of arrays
-     *     where 0 are the attribute arguments and 1 is a target class.
-     * @param array<class-string, array<array{ mixed[], class-string, non-empty-string }>> $targetMethods
+     *     where `0` is the serialized attribute arguments and `1` is a target class.
+     * @param array<class-string, array<array{ string, class-string, non-empty-string }>> $targetMethods
      *     Where _key_ is an attribute class and _value_ an array of arrays
-     *     where 0 are the attribute arguments, 1 is a target class, and 2 is the target method.
-     * @param array<class-string, array<array{ mixed[], class-string, non-empty-string }>> $targetProperties
+     *     where `0` is the serialized attribute arguments, `1` is a target class, and `2` is the target method.
+     * @param array<class-string, array<array{ string, class-string, non-empty-string }>> $targetProperties
      *     Where _key_ is an attribute class and _value_ an array of arrays
-     *     where 0 are the attribute arguments, 1 is a target class, and 2 is the target property.
-     * @param array<class-string, array<array{ mixed[], class-string, non-empty-string, non-empty-string }>> $targetParameters
-     *     Where _key_ is an attribute class and _value_ an array of arrays where 0 are the
-     *     attribute arguments, 1 is a target class, 2 is the target method, and 3 is the target parameter.
+     *     where `0` is the serialized attribute arguments, `1` is a target class, and `2` is the target property.
+     * @param array<class-string, array<array{ string, class-string, non-empty-string, non-empty-string }>> $targetParameters
+     *     Where _key_ is an attribute class and _value_ an array of arrays
+     *     where `0` are the serialized attribute arguments, `1` is a target class, `2` is the target method, and `3` is the target parameter.
      */
     public function __construct(
         private array $targetClasses,
@@ -53,15 +53,15 @@ final class Collection
      * @template T of object
      *
      * @param class-string<T> $attribute
-     * @param array<mixed> $arguments
+     * @param string $arguments The serialized arguments
      * @param class-string $class
      *
      * @return TargetClass<T>
      */
-    private static function createClassAttribute(string $attribute, array $arguments, string $class): object
+    private static function createClassAttribute(string $attribute, string $arguments, string $class): object
     {
         try {
-            $a = new $attribute(...$arguments);
+            $a = new $attribute(...unserialize($arguments));
             return new TargetClass($a, $class);
         } catch (Throwable $e) {
             throw new RuntimeException(
@@ -90,7 +90,7 @@ final class Collection
      * @template T of object
      *
      * @param class-string<T> $attribute
-     * @param array<mixed> $arguments
+     * @param string $arguments The serialized arguments
      * @param class-string $class
      * @param non-empty-string $method
      *
@@ -98,12 +98,12 @@ final class Collection
      */
     private static function createMethodAttribute(
         string $attribute,
-        array $arguments,
+        string $arguments,
         string $class,
         string $method,
     ): object {
         try {
-            $a = new $attribute(...$arguments);
+            $a = new $attribute(...unserialize($arguments));
             return new TargetMethod($a, $class, $method);
         } catch (Throwable $e) {
             throw new RuntimeException(
@@ -132,7 +132,7 @@ final class Collection
      * @template T of object
      *
      * @param class-string<T> $attribute
-     * @param array<mixed> $arguments
+     * @param string $arguments The serialized arguments
      * @param class-string $class
      * @param non-empty-string $method
      * @param non-empty-string $parameter
@@ -141,13 +141,13 @@ final class Collection
      */
     private static function createParameterAttribute(
         string $attribute,
-        array $arguments,
+        string $arguments,
         string $class,
         string $method,
         string $parameter,
     ): object {
         try {
-            $a = new $attribute(...$arguments);
+            $a = new $attribute(...unserialize($arguments));
             return new TargetParameter($a, $class, $method, $parameter);
         } catch (Throwable $e) {
             throw new RuntimeException(
@@ -176,7 +176,7 @@ final class Collection
      * @template T of object
      *
      * @param class-string<T> $attribute
-     * @param array<mixed> $arguments
+     * @param string $arguments The serialized arguments
      * @param class-string $class
      * @param non-empty-string $property
      *
@@ -184,12 +184,12 @@ final class Collection
      */
     private static function createPropertyAttribute(
         string $attribute,
-        array $arguments,
+        string $arguments,
         string $class,
         string $property,
     ): object {
         try {
-            $a = new $attribute(...$arguments);
+            $a = new $attribute(...unserialize($arguments));
             return new TargetProperty($a, $class, $property);
         } catch (Throwable $e) {
             throw new RuntimeException(

--- a/src/TransientCollectionRenderer.php
+++ b/src/TransientCollectionRenderer.php
@@ -52,11 +52,12 @@ final class TransientCollectionRenderer
      * @param iterable<class-string, iterable<TransientTargetClass|TransientTargetMethod|TransientTargetParameter|TransientTargetProperty>> $targetByClass
      *
      * @return array<class-string, array<array{
-     *     array<int|string, mixed>,
+     *     string,
      *     class-string,
      *     2?:non-empty-string,
      *     3?:non-empty-string
-     * }>>
+     * }>> Where _key_ is an attribute class and _value_ is an array of parameters,
+     *     where `1` is the serialized arguments and `2` is the target class.
      */
     private static function targetsToArray(iterable $targetByClass): array
     {
@@ -64,7 +65,7 @@ final class TransientCollectionRenderer
 
         foreach ($targetByClass as $class => $targets) {
             foreach ($targets as $t) {
-                $a = [ $t->arguments, $class ];
+                $a = [ serialize($t->arguments), $class ];
 
                 if ($t instanceof TransientTargetParameter) {
                     $a[] = $t->method;

--- a/tests/Acme81/Attribute/SampleNested.php
+++ b/tests/Acme81/Attribute/SampleNested.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Acme81\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class SampleNested
+{
+    public function __construct(
+        public SampleNestedValue $value,
+    ) {
+    }
+}

--- a/tests/Acme81/Attribute/SampleNestedValue.php
+++ b/tests/Acme81/Attribute/SampleNestedValue.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Acme81\Attribute;
+
+class SampleNestedValue
+{
+    public function __construct(
+        public int $value
+    ) {
+    }
+}

--- a/tests/Acme81/PSR4/Presentation/ArticleController.php
+++ b/tests/Acme81/PSR4/Presentation/ArticleController.php
@@ -6,8 +6,11 @@ use Acme81\Attribute\Get;
 use Acme81\Attribute\Method;
 use Acme81\Attribute\Post;
 use Acme81\Attribute\Route;
+use Acme81\Attribute\SampleNested;
+use Acme81\Attribute\SampleNestedValue;
 
 #[Route('/articles')]
+#[SampleNested(new SampleNestedValue(1))]
 class ArticleController
 {
     #[Route('/:id', method: Method::GET)]

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -43,17 +43,17 @@ final class CollectionTest extends TestCase
         $collection = new Collection(
             targetClasses: [
                 Permission::class => [
-                    [ [ 'Permission' => 'is_admin' ], DeleteMenu::class ],
+                    [ serialize([ 'Permission' => 'is_admin' ]), DeleteMenu::class ],
                 ]
             ],
             targetMethods: [
                 Route::class => [
-                    [ [ 'Method' => 'GET' ], ArticleController::class, 'list' ],
+                    [ serialize([ 'Method' => 'GET' ]), ArticleController::class, 'list' ],
                 ]
             ],
             targetProperties: [
                 Serial::class => [
-                    [ [ 'Primary' => true ], Article::class, 'id' ],
+                    [ serialize([ 'Primary' => true ]), Article::class, 'id' ],
                 ]
             ],
             targetParameters: [
@@ -101,9 +101,9 @@ final class CollectionTest extends TestCase
         $collection = new Collection(
             targetClasses: [
                 Route::class => [
-                    [ [ 'pattern' => '/articles' ], ArticleController::class ],
-                    [ [ 'pattern' => '/images' ], ImageController::class ],
-                    [ [ 'pattern' => '/files' ], FileController::class ],
+                    [ serialize([ 'pattern' => '/articles' ]), ArticleController::class ],
+                    [ serialize([ 'pattern' => '/images' ]), ImageController::class ],
+                    [ serialize([ 'pattern' => '/files' ]), FileController::class ],
                 ],
             ],
             targetMethods: [
@@ -131,13 +131,13 @@ final class CollectionTest extends TestCase
             ],
             targetMethods: [
                 Route::class => [
-                    [ [ 'pattern' => '/recent' ], ArticleController::class, 'recent' ],
+                    [ serialize([ 'pattern' => '/recent' ]), ArticleController::class, 'recent' ],
                 ],
                 Get::class => [
-                    [ [ ], ArticleController::class, 'show' ],
+                    [ serialize([ ]), ArticleController::class, 'show' ],
                 ],
                 Post::class => [
-                    [ [ ], ArticleController::class, 'create' ],
+                    [ serialize([ ]), ArticleController::class, 'create' ],
                 ],
             ],
             targetProperties: [
@@ -166,12 +166,12 @@ final class CollectionTest extends TestCase
             ],
             targetParameters: [
                 ParameterA::class => [
-                    [ [ 'a' ], ArticleController::class, 'myMethod', 'myParamA', ],
-                    [ [ 'a2' ], ArticleController::class, 'myMethod', 'myParamA2' ],
-                    [ [ 'a3' ], ArticleController::class, 'myFoo', 'fooParam' ],
+                    [ serialize([ 'a' ]), ArticleController::class, 'myMethod', 'myParamA', ],
+                    [ serialize([ 'a2' ]), ArticleController::class, 'myMethod', 'myParamA2' ],
+                    [ serialize([ 'a3' ]), ArticleController::class, 'myFoo', 'fooParam' ],
                 ],
                 ParameterB::class => [
-                    [ [ 'b', 'more data'], ArticleController::class, 'myMethod', 'myParamB' ],
+                    [ serialize([ 'b', 'more data']), ArticleController::class, 'myMethod', 'myParamB' ],
                 ],
             ]
         );
@@ -192,27 +192,27 @@ final class CollectionTest extends TestCase
             ],
             targetMethods: [
                 Route::class => [
-                    [ [ 'pattern' => '/recent' ], ArticleController::class, 'recent' ],
+                    [ serialize([ 'pattern' => '/recent' ]), ArticleController::class, 'recent' ],
                 ],
                 Get::class => [
-                    [ [ ], ArticleController::class, 'show' ],
+                    [ serialize([ ]), ArticleController::class, 'show' ],
                 ],
                 Post::class => [
-                    [ [ ], ArticleController::class, 'create' ],
+                    [ serialize([ ]), ArticleController::class, 'create' ],
                 ],
             ],
             targetProperties: [
                 Id::class => [
-                    [ [ ], Article::class, 'id' ],
+                    [ serialize([ ]), Article::class, 'id' ],
                 ],
                 Serial::class => [
-                    [ [ ], Article::class, 'id' ],
+                    [ serialize([ ]), Article::class, 'id' ],
                 ],
                 Varchar::class => [
-                    [ [ 'size' => 80 ], Article::class, 'title' ],
+                    [ serialize([ 'size' => 80 ]), Article::class, 'title' ],
                 ],
                 Text::class => [
-                    [ [ ], Article::class, 'body' ],
+                    [ serialize([ ]), Article::class, 'body' ],
                 ]
             ],
             targetParameters: [
@@ -236,30 +236,30 @@ final class CollectionTest extends TestCase
         $collection = new Collection(
             targetClasses: [
                 Index::class => [
-                    [ [ 'slug', 'unique' => true ], Article::class ],
+                    [ serialize([ 'slug', 'unique' => true ]), Article::class ],
                 ],
                 Route::class => [ // trap
-                    [ [ 'pattern' => '/articles' ], ArticleController::class ],
+                    [ serialize([ 'pattern' => '/articles' ]), ArticleController::class ],
                 ],
             ],
             targetMethods: [
                 Route::class => [ // trap
-                    [ [ 'pattern' => '/recent' ], ArticleController::class, 'recent' ],
+                    [ serialize([ 'pattern' => '/recent' ]), ArticleController::class, 'recent' ],
                 ],
             ],
             targetProperties: [
                 Id::class => [
-                    [ [ ], Article::class, 'id' ],
+                    [ serialize([ ]), Article::class, 'id' ],
                 ],
                 Serial::class => [
-                    [ [ ], Article::class, 'id' ],
+                    [ serialize([ ]), Article::class, 'id' ],
                 ],
                 Varchar::class => [
-                    [ [ 'size' => 80 ], Article::class, 'title' ],
-                    [ [ 'size' => 80 ], Article::class, 'slug' ],
+                    [ serialize([ 'size' => 80 ]), Article::class, 'title' ],
+                    [ serialize([ 'size' => 80 ]), Article::class, 'slug' ],
                 ],
                 Text::class => [
-                    [ [ ], Article::class, 'body' ],
+                    [ serialize([ ]), Article::class, 'body' ],
                 ]
             ],
             targetParameters: [

--- a/tests/CollectorTestAbstract.php
+++ b/tests/CollectorTestAbstract.php
@@ -350,6 +350,24 @@ abstract class CollectorTestAbstract extends TestCase
     /**
      * @requires PHP >= 8.1
      */
+    public function testNestedAttributes81(): void
+    {
+        $expected = [
+            new TargetClass(
+                new \Acme81\Attribute\SampleNested(new \Acme81\Attribute\SampleNestedValue(1)),
+                \Acme81\PSR4\Presentation\ArticleController::class,
+            )
+        ];
+        $actual = Attributes::filterTargetClasses(
+            Attributes::predicateForAttributeInstanceOf(\Acme81\Attribute\SampleNested::class)
+        );
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @requires PHP >= 8.1
+     */
     public function testFilterTargetMethods81(): void
     {
         $expected = [


### PR DESCRIPTION
Nested attributes introduced in PHP 8.1 are not supported at the moment. Because the attribute arguments are exported with `var_export()`, nested attributes need to implement `__set_state`, otherwise, reading the attributes will result in an error, as reported by #28.

## Proposed solution

To support nested attributes, attribute arguments should be serialized instead of exported.