### PR TITLE
Collect attributes from interfaces and traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # CHANGELOG
 
+## v2.1.0
+
+### New Requirements
+
+None
+
+### New features
+
+Attributes are now collected from interfaces and traits as well as classes.
+
+### Deprecated Features
+
+None
+
+### Backward Incompatible Changes
+
+None
+
+### Other Changes
+
+None
+
+
+
 ## v2.0.2
 
 ### New Requirements

--- a/src/Filter/ClassFilter.php
+++ b/src/Filter/ClassFilter.php
@@ -6,22 +6,20 @@ use olvlvl\ComposerAttributeCollector\Filter;
 use olvlvl\ComposerAttributeCollector\Logger;
 use Throwable;
 
+use function class_exists;
 use function interface_exists;
+use function trait_exists;
 
-final class InterfaceFilter implements Filter
+final class ClassFilter implements Filter
 {
     public function filter(string $filepath, string $class, Logger $log): bool
     {
         try {
-            if (interface_exists($class)) {
-                return false;
-            }
+            return class_exists($class) || interface_exists($class) || trait_exists($class);
         } catch (Throwable $e) {
             $log->warning("Discarding '$class' because an error occurred during loading: {$e->getMessage()}");
 
             return false;
         }
-
-        return true;
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -11,7 +11,7 @@ use Composer\Util\Platform;
 use olvlvl\ComposerAttributeCollector\Datastore\FileDatastore;
 use olvlvl\ComposerAttributeCollector\Datastore\RuntimeDatastore;
 use olvlvl\ComposerAttributeCollector\Filter\ContentFilter;
-use olvlvl\ComposerAttributeCollector\Filter\InterfaceFilter;
+use olvlvl\ComposerAttributeCollector\Filter\ClassFilter;
 use olvlvl\ComposerAttributeCollector\Logger\ComposerLogger;
 
 use function file_exists;
@@ -164,7 +164,7 @@ final class Plugin implements PluginInterface, EventSubscriberInterface
     {
         return new Filter\Chain([
             new ContentFilter(),
-            new InterfaceFilter()
+            new ClassFilter()
         ]);
     }
 

--- a/tests/Acme/Attribute/AutowiredService.php
+++ b/tests/Acme/Attribute/AutowiredService.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Acme\Attribute;
+
+use Attribute;
+
+#[Attribute(flags: Attribute::TARGET_CLASS)]
+final class AutowiredService
+{
+    /**
+     * @param true|list<class-string>|class-string $as
+     */
+    public function __construct(
+        public ?string $name = null,
+        public ?string $factory = null,
+        public bool|array|string $as = true,
+    ) {
+    }
+}

--- a/tests/Acme/Filter/ClassFilterTest.php
+++ b/tests/Acme/Filter/ClassFilterTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Acme\Filter;
+
+use olvlvl\ComposerAttributeCollector\Filter\ClassFilter;
+use olvlvl\ComposerAttributeCollector\Logger;
+use PHPUnit\Framework\TestCase;
+use tests\olvlvl\ComposerAttributeCollector\FakeLogger;
+
+final class ClassFilterTest extends TestCase
+{
+    private string $path;
+    private ClassFilter $sut;
+    private FakeLogger $log;
+
+    protected function setUp(): void
+    {
+        // The path doesn't matter.
+        $this->path = uniqid();
+        $this->sut = new ClassFilter();
+        $this->log = new FakeLogger();
+
+        parent::setUp();
+    }
+
+    public function testWithClass(): void
+    {
+        $actual = $this->sut->filter($this->path, \Acme\PSR4\CreateMenuHandler::class, $this->log);
+
+        $this->assertTrue($actual);
+    }
+
+    public function testWithInterface(): void
+    {
+        $actual = $this->sut->filter($this->path, \Acme\PSR4\SignatureMapProvider::class, $this->log);
+
+        $this->assertTrue($actual);
+    }
+
+    public function testWithTrait(): void
+    {
+        $actual = $this->sut->filter($this->path, \Acme\PSR4\SampleTrait::class, $this->log);
+
+        $this->assertTrue($actual);
+    }
+
+    public function testDiscardOnError(): void
+    {
+        $log = $this->createMock(Logger::class);
+        $log->expects($this->once())
+            ->method('warning')
+            ->with($this->stringStartsWith("Discarding 'Acme\PSR4\MissingInterface"));
+
+        $actual = $this->sut->filter($this->path, \Acme\PSR4\MissingInterface::class, $log);
+
+        $this->assertFalse($actual);
+    }
+}

--- a/tests/Acme/PSR4/SampleTrait.php
+++ b/tests/Acme/PSR4/SampleTrait.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Acme\PSR4;
+
+trait SampleTrait
+{
+}

--- a/tests/Acme/PSR4/SignatureMapProvider.php
+++ b/tests/Acme/PSR4/SignatureMapProvider.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Acme\PSR4;
+
+use Acme\Attribute\AutowiredService;
+
+#[AutowiredService(factory: '@Acme\PSR4\SignatureMap\SignatureMapProviderFactory::create')]
+interface SignatureMapProvider
+{
+}

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -16,6 +16,7 @@ use Acme\Attribute\ActiveRecord\SchemaAttribute;
 use Acme\Attribute\ActiveRecord\Serial;
 use Acme\Attribute\ActiveRecord\Text;
 use Acme\Attribute\ActiveRecord\Varchar;
+use Acme\Attribute\AutowiredService;
 use Acme\Attribute\Get;
 use Acme\Attribute\Handler;
 use Acme\Attribute\Permission;
@@ -129,7 +130,13 @@ final class PluginTest extends TestCase
                 [
                     [ new Index('active'), \Acme\PSR4\ActiveRecord\Article::class ],
                 ]
-            ]
+            ],
+            [
+                AutowiredService::class,
+                [
+                    [ new AutowiredService(factory: '@Acme\PSR4\SignatureMap\SignatureMapProviderFactory::create'), \Acme\PSR4\SignatureMapProvider::class ],
+                ]
+            ],
 
         ];
     }


### PR DESCRIPTION
Attributes are now collected from interfaces and traits as well as classes, allowing the following kind of setup:

```php

#[AutowiredService(factory: '@PHPStan\Reflection\SignatureMap\SignatureMapProviderFactory::create')]
interface SignatureMapProvider
{
    // ...
```
