### PR TITLE
A way to force attribute collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,28 @@ None
 
 ### New features
 
-Attributes are now collected from interfaces and traits as well as classes.
+- [#38](https://github.com/olvlvl/composer-attribute-collector/pull/38) Attributes are now collected from interfaces as well as classes.
 
-Parameter attributes are now collected. Use the method `findTargetParameters()`
-to find target parameters, and the method `filterTargetParameters()` to filter
-target parameters according to a predicate.
+- [#37](https://github.com/olvlvl/composer-attribute-collector/pull/37) Parameter attributes are now collected. Use the method `findTargetParameters()` to find target parameters, and the method `filterTargetParameters()` to filter target parameters according to a predicate. (@staabm @olvlvl)
+
+- [#39](https://github.com/olvlvl/composer-attribute-collector/pull/39) The `InheritsAttributes` attribute can be used on classes that inherit their attributes from traits, properties, or methods, and were previously ignored by the collection process.
+
+    ```php
+    trait UrlTrait
+    {
+        #[UrlGetter]
+        public function get_url(): string
+        {
+            return '/url';
+        }
+    }
+
+    #[InheritsAttributes]
+    class InheritedAttributeSample
+    {
+        use UrlTrait;
+    }
+    ```
 
 ### Deprecated Features
 
@@ -73,10 +90,11 @@ None
 
 ### Other Changes
 
-- #26 Fix enum support on PHP < 8.2.0 – @mnavarrocarter
+- #26 Fix enum support on PHP < 8.2.0 (@mnavarrocarter)
 
 
-## v1.2 to v2.0
+
+## v2.0.0
 
 ### New Requirements
 
@@ -100,7 +118,7 @@ None
 
 
 
-## v1.1 to v1.2
+## v1.2.0
 
 ### New Requirements
 
@@ -127,7 +145,7 @@ None
 
 
 
-## v1.0 to v1.1
+## v1.1.0
 
 ### New Requirements
 

--- a/README.md
+++ b/README.md
@@ -274,7 +274,29 @@ watchers][phpstorm-watchers]. You could also use [spatie/file-system-watcher][],
 PHP. If the plugin is too slow for your liking, try running the command with
 `COMPOSER_ATTRIBUTE_COLLECTOR_USE_CACHE=yes`, it will enable caching and speed up consecutive runs.
 
+**How do I include a class that inherits its attributes?**
 
+To speed up the collection process, the plugin first looks at PHP files as plain text for hints of
+attribute usage. If a class inherits its attributes from traits, properties, or methods, it is
+ignored. Use the attribute `[#\olvlvl\ComposerAttributeCollector\InheritsAttributes]` to force the
+collection.
+
+```php
+trait UrlTrait
+{
+    #[UrlGetter]
+    public function get_url(): string
+    {
+        return '/url';
+    }
+}
+
+#[InheritsAttributes]
+class InheritedAttributeSample
+{
+    use UrlTrait;
+}
+```
 
 ----------
 

--- a/src/ClassAttributeCollector.php
+++ b/src/ClassAttributeCollector.php
@@ -116,6 +116,7 @@ class ClassAttributeCollector
         static $ignored = [
             \ReturnTypeWillChange::class => true,
             \SensitiveParameter::class => true,
+            InheritsAttributes::class => true,
         ];
 
         return isset($ignored[$attribute->getName()]); // @phpstan-ignore offsetAccess.nonOffsetAccessible

--- a/src/Filter/ClassFilter.php
+++ b/src/Filter/ClassFilter.php
@@ -15,7 +15,7 @@ final class ClassFilter implements Filter
     public function filter(string $filepath, string $class, Logger $log): bool
     {
         try {
-            return class_exists($class) || interface_exists($class) || trait_exists($class);
+            return class_exists($class) || interface_exists($class) || !trait_exists($class);
         } catch (Throwable $e) {
             $log->warning("Discarding '$class' because an error occurred during loading: {$e->getMessage()}");
 

--- a/src/InheritsAttributes.php
+++ b/src/InheritsAttributes.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace olvlvl\ComposerAttributeCollector;
+
+use Attribute;
+
+/**
+ * Use this attribute when a class inherits attributes from traits or parents and is ignored by the collector.
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+final class InheritsAttributes
+{
+}

--- a/tests/Acme/Attribute/Routing/UrlGetter.php
+++ b/tests/Acme/Attribute/Routing/UrlGetter.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Acme\Attribute\Routing;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class UrlGetter
+{
+}

--- a/tests/Acme/Filter/ClassFilterTest.php
+++ b/tests/Acme/Filter/ClassFilterTest.php
@@ -41,7 +41,7 @@ final class ClassFilterTest extends TestCase
     {
         $actual = $this->sut->filter($this->path, \Acme\PSR4\SampleTrait::class, $this->log);
 
-        $this->assertTrue($actual);
+        $this->assertFalse($actual);
     }
 
     public function testDiscardOnError(): void

--- a/tests/Acme/PSR4/InheritedAttributeSample.php
+++ b/tests/Acme/PSR4/InheritedAttributeSample.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Acme\PSR4;
+
+use Acme\PSR4\Routing\UrlTrait;
+use olvlvl\ComposerAttributeCollector\InheritsAttributes;
+
+#[InheritsAttributes]
+class InheritedAttributeSample
+{
+    use UrlTrait;
+}

--- a/tests/Acme/PSR4/Routing/UrlTrait.php
+++ b/tests/Acme/PSR4/Routing/UrlTrait.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Acme\PSR4\Routing;
+
+use Acme\Attribute\Routing\UrlGetter;
+
+trait UrlTrait
+{
+    #[UrlGetter]
+    public function get_url(): string
+    {
+        return '/url';
+    }
+}

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/*
- * (c) Olivier Laviale <olivier.laviale@gmail.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace tests\olvlvl\ComposerAttributeCollector;
 
 use Acme\Attribute\ActiveRecord\Boolean;
@@ -22,6 +15,7 @@ use Acme\Attribute\Handler;
 use Acme\Attribute\Permission;
 use Acme\Attribute\Resource;
 use Acme\Attribute\Route;
+use Acme\Attribute\Routing\UrlGetter;
 use Acme\Attribute\Subscribe;
 use Acme\PSR4\Presentation\ArticleController;
 use Acme81\Attribute\ParameterA;
@@ -48,9 +42,6 @@ final class PluginTest extends TestCase
 {
     private static bool $initialized = false;
 
-    /**
-     * @throws ReflectionException
-     */
     protected function setUp(): void
     {
         parent::setUp();
@@ -165,37 +156,43 @@ final class PluginTest extends TestCase
     {
         return [
 
+//            [
+//                Route::class,
+//                [
+//                    [
+//                        new Route("/articles/method/", 'GET', 'articles:method'),
+//                        'Acme\PSR4\Presentation\ArticleController::aMethod'
+//                    ],
+//                    [
+//                        new Route("/articles", 'GET', 'articles:list'),
+//                        'Acme\PSR4\Presentation\ArticleController::list'
+//                    ],
+//                    [
+//                        new Route("/articles/{id}", 'GET', 'articles:show'),
+//                        'Acme\PSR4\Presentation\ArticleController::show'
+//                    ],
+//                ]
+//            ],
+//            [
+//                Get::class,
+//                [
+//                    [ new Get(), 'Acme\Presentation\FileController::list' ],
+//                    [ new Get('/{id}'), 'Acme\Presentation\FileController::show' ],
+//                    [ new Get(), 'Acme\Presentation\ImageController::list' ],
+//                    [ new Get('/{id}'), 'Acme\Presentation\ImageController::show' ],
+//                ]
+//            ],
+//            [
+//                Subscribe::class,
+//                [
+//                    [ new Subscribe(), 'Acme\PSR4\SubscriberA::onEventA' ],
+//                    [ new Subscribe(), 'Acme\PSR4\SubscriberB::onEventA' ],
+//                ]
+//            ],
             [
-                Route::class,
+                UrlGetter::class,
                 [
-                    [
-                        new Route("/articles/method/", 'GET', 'articles:method'),
-                        'Acme\PSR4\Presentation\ArticleController::aMethod'
-                    ],
-                    [
-                        new Route("/articles", 'GET', 'articles:list'),
-                        'Acme\PSR4\Presentation\ArticleController::list'
-                    ],
-                    [
-                        new Route("/articles/{id}", 'GET', 'articles:show'),
-                        'Acme\PSR4\Presentation\ArticleController::show'
-                    ],
-                ]
-            ],
-            [
-                Get::class,
-                [
-                    [ new Get(), 'Acme\Presentation\FileController::list' ],
-                    [ new Get('/{id}'), 'Acme\Presentation\FileController::show' ],
-                    [ new Get(), 'Acme\Presentation\ImageController::list' ],
-                    [ new Get('/{id}'), 'Acme\Presentation\ImageController::show' ],
-                ]
-            ],
-            [
-                Subscribe::class,
-                [
-                    [ new Subscribe(), 'Acme\PSR4\SubscriberA::onEventA' ],
-                    [ new Subscribe(), 'Acme\PSR4\SubscriberB::onEventA' ],
+                    [ new UrlGetter(), 'Acme\PSR4\InheritedAttributeSample::get_url' ],
                 ]
             ],
 


### PR DESCRIPTION
Attributes are not collected when they are on a trait and the class using the trait doesn't have attributes:

```php
trait UrlTrait
{
    #[UrlGetter]
    public function get_url(): string
    {
        return '/url';
    }
}

class InheritedAttributeSample
{
    use UrlTrait;
}
```

## Proposed solution

Add a `InheritsAttributes` to force the collection.

```php
#[InheritsAttributes]
class InheritedAttributeSample
{
    use UrlTrait;
}
```