### PR TITLE
PartialComposer is only available since Composer v2.3

### DIFF
--- a/.github/workflows/cases.yml
+++ b/.github/workflows/cases.yml
@@ -5,20 +5,24 @@ on:
     - main
     - "2.**"
     - "case-**"
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   case-incompatible-signature:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version:
-          - "8.0"
-        composer-version:
-          - "v2.4.0"
-          - "v2"
-        composer-tweak:
-          - "--prefer-lowest"
-          - ""
+        includes:
+          - php-version: "8.0"
+            composer-version: "v2.3.0"
+            composer-tweak: "--prefer-lowest"
+          - php-version: "8.5"
+            composer-version: "v2"
+            composer-tweak: ""
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,12 +40,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version:
-          - "8.2"
-          - "8.4"
-        composer-version:
-          - "v2.4.0"
-          - "v2"
+        includes:
+          - php-version: "8.2"
+            composer-version: "v2.3.0"
+          - php-version: "8.5"
+            composer-version: "latest"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -60,12 +63,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version:
-          - "8.2"
-          - "8.4"
-        composer-version:
-          - "v2.4.0"
-          - "v2"
+        includes:
+          - php-version: "8.2"
+            composer-version: "v2.3.0"
+          - php-version: "8.5"
+            composer-version: "latest"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
     branches-ignore:
     - 'case-**'
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
     branches-ignore:
     - 'case-**'
 
@@ -14,14 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version:
-        - "8.0"
-        - "8.1"
-        - "8.2"
-        - "8.5"
-        composer-tweak:
-          - "--prefer-lowest"
-          - ""
+        includes:
+          - php-version: "8.0"
+            composer-tweak: "--prefer-lowest"
+          - php-version: "8.5"
+            composer-tweak: ""
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -48,7 +49,7 @@ jobs:
       run: make test-coveralls
 
     - name: Upload code coverage
-      if: ${{ matrix.php-version == '8.0' && matrix.composer-tweak == '' }}
+      if: ${{ matrix.php-version == '8.5' && matrix.composer-tweak == '' }}
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # CHANGELOG
 
+## v2.1.1
+
+### New Requirements
+
+- composer-plugin-api v2.3
+
+### New features
+
+None
+
+### Deprecated Features
+
+None
+
+### Backward Incompatible Changes
+
+None
+
+### Other Changes
+
+None
+
+
+
 ## v2.1.0
 
 ### New Requirements

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 ARG PHP_TAG=8.0-cli-trixie
+ARG COMPOSER_TAG=2.3
+
+FROM composer:${COMPOSER_TAG} AS composer_source
 FROM php:${PHP_TAG}
 
 RUN <<-EOF
@@ -23,7 +26,7 @@ RUN <<-EOF
 	SHELL
 EOF
 
-COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+COPY --from=composer_source /usr/bin/composer /usr/bin/composer
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV PATH="/root/.composer/vendor/bin:${PATH}"
 

--- a/cases/laravel/Dockerfile
+++ b/cases/laravel/Dockerfile
@@ -1,4 +1,4 @@
-ARG PHP_TAG=8.2-cli-buster
+ARG PHP_TAG=8.2-cli-trixie
 FROM php:${PHP_TAG}
 
 RUN <<-EOF
@@ -23,6 +23,6 @@ RUN <<-EOF
 	SHELL
 EOF
 
-COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.3 /usr/bin/composer /usr/bin/composer
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV PATH="/root/.composer/vendor/bin:${PATH}"

--- a/cases/laravel/docker-compose.yaml
+++ b/cases/laravel/docker-compose.yaml
@@ -9,7 +9,6 @@ services:
       PHP_IDE_CONFIG: 'serverName=olvlvl/attribute-collector'
     volumes:
       - .:/app:delegated
-      - ~/.composer:/root/.composer:delegated
     working_dir: /app
   app84:
     build:
@@ -20,5 +19,4 @@ services:
       PHP_IDE_CONFIG: 'serverName=olvlvl/attribute-collector'
     volumes:
       - .:/app:delegated
-      - ~/.composer:/root/.composer:delegated
     working_dir: /app

--- a/cases/laravel/test.php
+++ b/cases/laravel/test.php
@@ -12,6 +12,15 @@ $expected = [
     new TargetClass(new SampleAttribute(), App\Providers\AppServiceProvider::class),
 ];
 
+$sortFn = fn($a, $b) => strcmp($a->name, $b->name);
+
+usort($actual, $sortFn);
+usort($expected, $sortFn);
+
+echo "Found Target Classes:\n";
+
 var_dump($actual);
 
 $actual == $expected or throw new \RuntimeException("Target classes don't match expected");
+
+echo "✓ Expectation matched, Yay!\n";

--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,11 @@
   },
   "require": {
     "php": ">=8.0",
-    "composer-plugin-api": "^2.0",
+    "composer-plugin-api": ">=2.3",
     "composer/class-map-generator": "^1.4"
   },
   "require-dev": {
-    "composer/composer": ">=2.4",
+    "composer/composer": ">=2.3",
     "phpstan/phpstan": "^2.1.17",
     "phpunit/phpunit": "^9.6.23"
   },

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
       context: .
       args:
         PHP_TAG: '8.0-cli-bullseye'
+        COMPOSER_TAG: '2.3'
     environment:
       PHP_IDE_CONFIG: 'serverName=olvlvl/attribute-collector'
     volumes:
@@ -38,6 +39,7 @@ services:
       context: .
       args:
         PHP_TAG: '8.5-cli-trixie'
+        COMPOSER_TAG: latest
     environment:
       PHP_IDE_CONFIG: 'serverName=olvlvl/attribute-collector'
     volumes:


### PR DESCRIPTION
### Problem

We use `PartialComposer` in `Config`, which is only available since Composer v2.3.

### Solution

Raise `composer-plugin-api` requirement to `>=2.3`.

Furthermore, the PHP 8.2 environment uses the lowest settings, whereas PHP 8.5 uses the highest.