### PR TITLE
Use PHP to execute the collector (Fix #49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # CHANGELOG
 
+## v2.1.2
+
+### New Requirements
+
+None
+
+### New features
+
+None
+
+### Deprecated Features
+
+None
+
+### Backward Incompatible Changes
+
+None
+
+### Other Changes
+
+Execute the collector with `/usr/bin/env php` instead of executing the script directly, because the
+permission might be dropped by indelicate unarchivers. (fix #49)
+
+
+
 ## v2.1.1
 
 ### New Requirements

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -93,7 +93,7 @@ final class Plugin implements PluginInterface, EventSubscriberInterface
 
     public static function dump(Config $config): void
     {
-        $cmd = __DIR__ . '/../collector.php';
+        $collector = __DIR__ . '/../collector.php';
         $tmpFile = tempnam(sys_get_temp_dir(), 'composer-attribute-collector-');
         if ($tmpFile === false) {
             throw new \RuntimeException('Unable to create temporary file');
@@ -101,7 +101,7 @@ final class Plugin implements PluginInterface, EventSubscriberInterface
         file_put_contents($tmpFile, serialize($config));
 
         try {
-            $process = new Process([ $cmd, $tmpFile ]);
+            $process = new Process([ "/usr/bin/env", "php", $collector, $tmpFile ]);
             $process->mustRun(function (string $type, string $line): void {
                 print($line);
             });


### PR DESCRIPTION
## Problem

The execution bit might be lost when the package is extracted, making `collector.php` not executable.

https://github.com/olvlvl/composer-attribute-collector/issues/49

## Solution

Use PHP to execute `collector.php`.