### PR TITLE
Use cases run against branch changes

### DIFF
--- a/.github/workflows/cases.yml
+++ b/.github/workflows/cases.yml
@@ -1,15 +1,5 @@
 name: cases
-on:
-  push:
-    branches:
-    - main
-    - "2.**"
-    - "case-**"
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
+on: [ push ]
 
 jobs:
   case-incompatible-signature:
@@ -34,6 +24,7 @@ jobs:
       - name: Run case
         run: |
           cd cases/incompatible-signature
+          make plugin-copy
           composer update --no-interaction --no-progress ${{ matrix.composer-tweak }}
 
   case-symfony:
@@ -56,6 +47,7 @@ jobs:
       - name: Run case
         run: |
           cd cases/symfony
+          make plugin-copy
           composer install --no-interaction --no-progress
           php test.php
 
@@ -80,5 +72,6 @@ jobs:
       - name: Run case
         run: |
           cd cases/laravel
+          make plugin-copy
           composer install --no-interaction --no-progress
           php test.php

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,12 +1,6 @@
 name: quality
 
-on:
-  push:
-    branches-ignore:
-    - 'case-**'
-  pull_request:
-    branches-ignore:
-    - 'case-**'
+on: [ push ]
 
 jobs:
   phpcs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,6 @@
 name: test
 
-on:
-  push:
-    branches-ignore:
-    - 'case-**'
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-    branches-ignore:
-    - 'case-**'
+on: [ push ]
 
 jobs:
   phpunit:

--- a/cases/incompatible-signature/Makefile
+++ b/cases/incompatible-signature/Makefile
@@ -13,21 +13,21 @@ plugin-copy:
 test-container: test-container80
 
 .PHONY: test-container80
-test-container80:
+test-container80: plugin-copy
 	@-docker compose run --rm app80 bash
 	@docker compose down -v
 
 .PHONY: test-container81
-test-container81:
+test-container81: plugin-copy
 	@-docker-compose run --rm app81 bash
 	@docker-compose down -v
 
 .PHONY: test-container82
-test-container82:
+test-container82: plugin-copy
 	@-docker compose run --rm app82 bash
 	@docker compose down -v
 
 .PHONY: test-container84
-test-container84:
+test-container84: plugin-copy
 	@-docker compose run --rm app84 bash
 	@docker compose down -v

--- a/cases/incompatible-signature/Makefile
+++ b/cases/incompatible-signature/Makefile
@@ -1,7 +1,13 @@
-# do not edit the following lines
+COPY=composer-attribute-collector/
 
 vendor:
 	@composer install --prefer-lowest
+
+.PHONY: plugin-copy
+plugin-copy:
+	cp -r ../../src $(COPY)
+	cp ../../composer.json $(COPY)
+	cp ../../collector.php $(COPY)
 
 .PHONY: test-container
 test-container: test-container80

--- a/cases/incompatible-signature/composer-attribute-collector/.gitignore
+++ b/cases/incompatible-signature/composer-attribute-collector/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/cases/incompatible-signature/composer.json
+++ b/cases/incompatible-signature/composer.json
@@ -1,8 +1,14 @@
 {
+  "repositories": [
+    {
+      "type": "path",
+      "url": "composer-attribute-collector"
+    }
+  ],
   "require": {
     "php": ">=8.0",
     "psr/log": "^3.0",
-    "olvlvl/composer-attribute-collector": "^2.1.0"
+    "olvlvl/composer-attribute-collector": "@dev"
   },
   "config": {
     "allow-plugins": {

--- a/cases/incompatible-signature/docker-compose.yaml
+++ b/cases/incompatible-signature/docker-compose.yaml
@@ -8,9 +8,9 @@ services:
     environment:
       PHP_IDE_CONFIG: 'serverName=olvlvl/attribute-collector'
     volumes:
-      - .:/app:delegated
+      - ./../../:/app:delegated
       - ~/.composer:/root/.composer:delegated
-    working_dir: /app
+    working_dir: /app/cases/incompatible-signature
   app81:
     build:
       context: .

--- a/cases/laravel/.editorconfig
+++ b/cases/laravel/.editorconfig
@@ -14,5 +14,5 @@ trim_trailing_whitespace = false
 [*.{yml,yaml}]
 indent_size = 2
 
-[docker-compose.yml]
+[{docker-compose.yml}]
 indent_size = 4

--- a/cases/laravel/Makefile
+++ b/cases/laravel/Makefile
@@ -1,17 +1,26 @@
-# do not edit the following lines
+COPY=composer-attribute-collector/
 
 vendor:
 	@composer install --prefer-lowest
+
+.PHONY: plugin-copy
+plugin-copy:
+	cp -r ../../src $(COPY)
+	cp ../../composer.json $(COPY)
+	cp ../../collector.php $(COPY)
 
 .PHONY: test-container
 test-container: test-container82
 
 .PHONY: test-container82
-test-container82:
+test-container82: plugin-copy
 	@-docker compose run --rm app82 bash
 	@docker compose down -v
 
 .PHONY: test-container84
-test-container84:
+test-container84: plugin-copy
 	@-docker compose run --rm app84 bash
 	@docker compose down -v
+
+test:
+	/usr/bin/env php test.php

--- a/cases/laravel/composer-attribute-collector/.gitignore
+++ b/cases/laravel/composer-attribute-collector/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/cases/laravel/composer.json
+++ b/cases/laravel/composer.json
@@ -8,11 +8,17 @@
         "framework"
     ],
     "license": "MIT",
+    "repositories": [
+        {
+            "type": "path",
+            "url": "composer-attribute-collector"
+        }
+    ],
     "require": {
         "php": "^8.2",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
-        "olvlvl/composer-attribute-collector": "^2.1"
+        "olvlvl/composer-attribute-collector": "@dev"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/cases/symfony/Makefile
+++ b/cases/symfony/Makefile
@@ -13,11 +13,11 @@ plugin-copy:
 test-container: test-container82
 
 .PHONY: test-container82
-test-container82:
+test-container82: plugin-copy
 	@-docker compose run --rm app82 bash
 	@docker compose down -v
 
 .PHONY: test-container84
-test-container84:
+test-container84: plugin-copy
 	@-docker compose run --rm app84 bash
 	@docker compose down -v

--- a/cases/symfony/Makefile
+++ b/cases/symfony/Makefile
@@ -1,7 +1,13 @@
-# do not edit the following lines
+COPY=composer-attribute-collector/
 
 vendor:
 	@composer install --prefer-lowest
+
+.PHONY: plugin-copy
+plugin-copy:
+	cp -r ../../src $(COPY)
+	cp ../../composer.json $(COPY)
+	cp ../../collector.php $(COPY)
 
 .PHONY: test-container
 test-container: test-container82

--- a/cases/symfony/composer-attribute-collector/.gitignore
+++ b/cases/symfony/composer-attribute-collector/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/cases/symfony/composer.json
+++ b/cases/symfony/composer.json
@@ -3,11 +3,17 @@
     "license": "proprietary",
     "minimum-stability": "stable",
     "prefer-stable": true,
+    "repositories": [
+        {
+            "type": "path",
+            "url": "composer-attribute-collector"
+        }
+    ],
     "require": {
         "php": ">=8.2",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "olvlvl/composer-attribute-collector": "^2.1",
+        "olvlvl/composer-attribute-collector": "@dev",
         "symfony/console": "7.3.*",
         "symfony/dotenv": "7.3.*",
         "symfony/flex": "^2.10",


### PR DESCRIPTION
### Problem

Use cases use a static version of the plugin; they are only tested when a new version is released, which is too late to find issues.

### Solution

Use the local file as the repository source for the plugin.