### PR TITLE
Track per-file mtime in MemoizeClassMapGenerator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ None
 
 ### New features
 
-None
+- [#60](https://github.com/olvlvl/composer-attribute-collector/pull/60) Track per-file mtime in MemoizeClassMapGenerator.
 
 ### Deprecated Features
 

--- a/src/MemoizeClassMapGenerator.php
+++ b/src/MemoizeClassMapGenerator.php
@@ -8,10 +8,10 @@ use RuntimeException;
 
 use function array_filter;
 use function array_merge;
+use function file_exists;
 use function filemtime;
 use function is_dir;
 use function is_int;
-use function time;
 
 use const ARRAY_FILTER_USE_KEY;
 
@@ -23,10 +23,9 @@ class MemoizeClassMapGenerator
     private const KEY = 'classmap';
 
     /**
-     * @var array<non-empty-string, array{ int, array<class-string, non-empty-string> }>
-     *     Where _key_ is a directory path and _value_ an array
-     *     where `0` is a timestamp, and `1` is an array
-     *     where _key_ is a class and _value_ its pathname.
+     * @var array<non-empty-string, array{ array<class-string, non-empty-string>, array<non-empty-string, int> }>
+     *     Where _key_ is a directory or file path and _value_ an array
+     *     where `0` is a class map, and `1` is a map of file paths to their mtimes.
      */
     private array $state;
 
@@ -62,7 +61,7 @@ class MemoizeClassMapGenerator
 
         $maps = [];
 
-        foreach ($this->state as [, $map]) {
+        foreach ($this->state as [$map]) {
             $maps[] = $map;
         }
 
@@ -82,30 +81,70 @@ class MemoizeClassMapGenerator
     public function scanPaths(string $path, ?string $excluded = null): void
     {
         $this->paths[$path] = true;
-        [ $timestamp ] = $this->state[$path] ?? [ 0 ];
+        [ , $cachedFileMtimes ] = $this->state[$path] ?? [ [], [] ];
 
-        if ($this->shouldUpdate($timestamp, $path)) {
+        if ($this->shouldUpdate($path, $cachedFileMtimes)) {
             $inner = new ClassMapGenerator();
             $inner->avoidDuplicateScans();
             $inner->scanPaths($path, $excluded);
             $map = $inner->getClassMap()->getMap();
 
-            $this->state[$path] = [ time(), $map ];
+            $fileMtimes = [];
+            foreach ($map as $filepath) {
+                $mtime = filemtime($filepath);
+                assert(is_int($mtime));
+                $fileMtimes[$filepath] = $mtime;
+            }
+
+            $this->state[$path] = [ $map, $fileMtimes ];
         }
     }
 
-    private function shouldUpdate(int $timestamp, string $path): bool
+    /**
+     * @param array<non-empty-string, int> $cachedFileMtimes
+     */
+    private function shouldUpdate(string $path, array $cachedFileMtimes): bool
     {
-        if (!$timestamp) {
+        if (!$cachedFileMtimes) {
             return true;
         }
 
-        $mtime = filemtime($path);
+        $maxCachedMtime = 0;
 
-        assert(is_int($mtime));
+        foreach ($cachedFileMtimes as $filepath => $cachedMtime) {
+            if ($cachedMtime > $maxCachedMtime) {
+                $maxCachedMtime = $cachedMtime;
+            }
 
-        if ($timestamp < $mtime) {
-            $diff = $mtime - $timestamp;
+            if (!file_exists($filepath)) {
+                $this->log->debug("Refresh class map: file '$filepath' was removed");
+
+                return true;
+            }
+
+            $currentMtime = filemtime($filepath);
+
+            assert(is_int($currentMtime));
+
+            if ($currentMtime !== $cachedMtime) {
+                $diff = $currentMtime - $cachedMtime;
+                $this->log->debug("Refresh class map: file '$filepath' changed ($diff sec)");
+
+                return true;
+            }
+        }
+
+        return $this->hasNewerDirectoryMtime($path, $maxCachedMtime);
+    }
+
+    private function hasNewerDirectoryMtime(string $path, int $maxCachedMtime): bool
+    {
+        $dirMtime = filemtime($path);
+
+        assert(is_int($dirMtime));
+
+        if ($dirMtime > $maxCachedMtime) {
+            $diff = $dirMtime - $maxCachedMtime;
             $this->log->debug("Refresh class map for path '$path' ($diff sec ago)");
 
             return true;
@@ -118,7 +157,7 @@ class MemoizeClassMapGenerator
 
         foreach (new DirectoryIterator($path) as $di) {
             if ($di->isDir() && !$di->isDot()) {
-                if ($this->shouldUpdate($timestamp, $di->getPathname())) {
+                if ($this->hasNewerDirectoryMtime($di->getPathname(), $maxCachedMtime)) {
                     return true;
                 }
             }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -25,7 +25,7 @@ final class Plugin implements PluginInterface, EventSubscriberInterface
 {
     public const CACHE_DIR = '.composer-attribute-collector';
     public const VERSION_MAJOR = 2;
-    public const VERSION_MINOR = 1;
+    public const VERSION_MINOR = 2;
 
     /**
      * @uses onPostAutoloadDump

--- a/tests/MemoizeClassMapGeneratorTest.php
+++ b/tests/MemoizeClassMapGeneratorTest.php
@@ -23,6 +23,8 @@ final class MemoizeClassMapGeneratorTest extends TestCase
         $remove = [
             self::DIR . 'a.php',
             self::DIR . 'a/b/c/b.php',
+            self::DIR . 'modification.php',
+            self::DIR . 'deletion.php',
         ];
 
         foreach ($remove as $filename) {
@@ -83,13 +85,47 @@ final class MemoizeClassMapGeneratorTest extends TestCase
         ], $map);
     }
 
+    public function testMemoizeDetectsFileModification(): void
+    {
+        self::write("modification.php", "<?php\nclass ModificationA {}");
+
+        $map = $this->map(self::DIR);
+        $this->assertEquals(['ModificationA' => self::DIR . 'modification.php'], $map);
+
+        self::write("modification.php", "<?php\nclass ModificationA {}\nclass ModificationB {}");
+
+        $map = $this->map(self::DIR);
+        $this->assertEquals([
+            'ModificationA' => self::DIR . 'modification.php',
+            'ModificationB' => self::DIR . 'modification.php',
+        ], $map);
+    }
+
+    public function testMemoizeDetectsFileDeletion(): void
+    {
+        self::write("deletion.php", "<?php\nclass DeletionA {}");
+
+        $map = $this->map(self::DIR);
+        $this->assertEquals(['DeletionA' => self::DIR . 'deletion.php'], $map);
+
+        unlink(self::DIR . 'deletion.php');
+
+        $map = $this->map(self::DIR);
+        $this->assertEmpty($map);
+    }
+
     private static function write(string $name, string $data): void
     {
-        file_put_contents(self::DIR . $name, $data);
+        static $offset = 0;
+        $offset++;
 
-        // Because the modified time granularity is a second, we need the set the time to the next second,
-        // so that we don't have to use sleep().
-        touch(self::DIR, time() + 1);
+        $file = self::DIR . $name;
+
+        file_put_contents($file, $data);
+
+        // Because the modified time granularity is a second, we use an incrementing offset
+        // to guarantee distinct mtimes without sleep().
+        touch($file, time() + $offset);
     }
 
     /**


### PR DESCRIPTION
The class map cache used a single directory timestamp to decide whether to re-scan. This works on macOS where APFS bubbles file content modifications up to the directory mtime, but fails on Linux and Windows where only directory entry creation/deletion updates it.

Store the mtime of every file in the cached class map alongside the map itself. On cache check, compare each cached file's current mtime against the stored value to detect modifications, and recursively check directory mtimes against the max cached file mtime to detect new files. This works identically on all OS/filesystem combinations.

Also explicitly detect deleted files via `file_exists()` rather than relying solely on directory mtime changes.

> [!IMPORTANT]
> Requires a minor bump because of the new cache layout