### PR TITLE
PHP 8.5 Closures in constant expressions are not supported yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,12 +228,12 @@ Use cases are available to test the plugin in real conditions:
 
 ## Frequently Asked Questions
 
-**Do I need to generate an optimized autoloader?**
+### Do I need to generate an optimized autoloader?
 
 You don't need to generate an optimized autoloader for this to work. The plugin uses code similar
 to Composer to find classes. Anything that works with Composer should work with the plugin.
 
-**Can I use the plugin during development?**
+### Can I use the plugin during development?
 
 Yes, you can use the plugin during development, but keep in mind the "attributes" file is only
 generated after the autoloader is dumped. If you modify attributes you will have to run
@@ -245,7 +245,7 @@ watchers][phpstorm-watchers]. You could also use [spatie/file-system-watcher][],
 PHP. If the plugin is too slow for your liking, try running the command with
 `COMPOSER_ATTRIBUTE_COLLECTOR_USE_CACHE=yes`, it will enable caching and speed up consecutive runs.
 
-**How do I include a class that inherits its attributes?**
+### How do I include a class that inherits its attributes?
 
 To speed up the collection process, the plugin first looks at PHP files as plain text for hints of
 attribute usage. If a class inherits its attributes from traits, properties, or methods, but doesn't
@@ -269,13 +269,51 @@ class InheritedAttributeSample
 }
 ```
 
+### The plugin fails when closures are used as parameter of an attribute
+
+The plugin fails when closures are used as parameter of an attribute because there's no way to
+serialize closures in PHP.
+
+```php
+// FAILS: The closure argument cannot be serialized by the collector
+#[Assert\When(
+    expression: static fn(Discount $d) =>$d->getType() === 'percent',
+    constraints: [new Assert\NotBlank()],
+)]
+private ?string $discountValue;
+```
+
+As a workaround, you can create a subclass and pass the closure during `__construct`. This
+works because the plugin serializes the arguments of the attribute, not the attribute itself.
+
+```php
+// WORKS: The custom attribute has no serialized arguments
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class DiscountPercentValidation extends Assert\When
+{
+    public function __construct()
+    {
+        parent::__construct(
+            expression: static fn(Discount $d) => $d->getType() === 'percent',
+            constraints: [new Assert\NotBlank()],
+        );
+    }
+}
+
+// Use your custom attribute without any arguments:
+#[DiscountPercentValidation]
+private ?string $discountValue;
+```
+
+
+
 ----------
 
 
 
 ## Continuous Integration
 
-The project is continuously tested by [GitHub actions](https://github.com/olvlvl/composer-attribute-collector/actions).
+The project is continuously tested by [GitHub Actions](https://github.com/olvlvl/composer-attribute-collector/actions).
 
 [![Cases](https://github.com/olvlvl/composer-attribute-collector/actions/workflows/cases.yml/badge.svg?branch=main)](https://github.com/olvlvl/composer-attribute-collector/actions/workflows/cases.yml)
 [![Tests](https://github.com/olvlvl/composer-attribute-collector/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/olvlvl/composer-attribute-collector/actions/workflows/test.yml)

--- a/src/TransientCollectionRenderer.php
+++ b/src/TransientCollectionRenderer.php
@@ -64,6 +64,8 @@ final class TransientCollectionRenderer
 
         foreach ($targetByClass as $class => $targets) {
             foreach ($targets as $t) {
+                self::assertExportable($t->arguments);
+
                 $a = [ $t->arguments, $class ];
 
                 if ($t instanceof TransientTargetParameter) {
@@ -83,5 +85,20 @@ final class TransientCollectionRenderer
         }
 
         return $by;
+    }
+
+    /**
+     * @param array<mixed> $arguments
+     */
+    private static function assertExportable(array $arguments): void
+    {
+        foreach ($arguments as $argument) {
+            if ($argument instanceof \Closure) {
+                throw new \InvalidArgumentException(
+                    "PHP 8.5 Closures in constant expressions are not supported yet." .
+                    " Please, check the README for a workaround."
+                );
+            }
+        }
     }
 }

--- a/tests/Acme/olvlvl/ComposerAttributeCollector/TransientCollectionRendererTest.php
+++ b/tests/Acme/olvlvl/ComposerAttributeCollector/TransientCollectionRendererTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace tests\olvlvl\ComposerAttributeCollector;
+
+use Acme85\Attribute\WithClosure;
+use Acme85\PSR4\SampleWithClosure;
+use olvlvl\ComposerAttributeCollector\TransientCollection;
+use olvlvl\ComposerAttributeCollector\TransientCollectionRenderer;
+use olvlvl\ComposerAttributeCollector\TransientTargetProperty;
+use PHPUnit\Framework\TestCase;
+
+final class TransientCollectionRendererTest extends TestCase
+{
+    /**
+     * @requires PHP >= 8.5
+     */
+    public function testShouldFailOnClosureAsArgument()
+    {
+        $collector = new TransientCollection();
+        $collector->addPropertyAttributes(WithClosure::class, [
+            new TransientTargetProperty(WithClosure::class, [
+                'name' => static function ($str) {
+                    return strtoupper($str);
+                }
+            ], SampleWithClosure::class),
+        ]);
+
+        $this->expectExceptionMessageMatches("/PHP 8\\.5 Closures in constant expressions are not supported yet/");
+
+        TransientCollectionRenderer::render($collector);
+    }
+}

--- a/tests/Acme85/Attribute/WithClosure.php
+++ b/tests/Acme85/Attribute/WithClosure.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Acme85\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class WithClosure
+{
+    public function __construct(\Closure $closure)
+    {
+    }
+}

--- a/tests/Acme85/PSR4/SampleWithClosure.php
+++ b/tests/Acme85/PSR4/SampleWithClosure.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Acme85\PSR4;
+
+use Acme85\Attribute\WithClosure;
+
+class SampleWithClosure
+{
+    #[WithClosure(static function ($str) {
+        return strtoupper($str);
+    })]
+    public string $name;
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,7 +7,12 @@ use olvlvl\ComposerAttributeCollector\Plugin;
 use function dirname;
 use function is_dir;
 
-require_once dirname(__DIR__) . '/vendor/autoload.php';
+$autoload = require dirname(__DIR__) . '/vendor/autoload.php';
+
+// Avoid Acme85 cases breaking older versions.
+if (PHP_VERSION_ID >= 85000) {
+    $autoload->addPsr4("Acme85\\", "tests/Acme85");
+}
 
 /**
  * @return non-empty-string


### PR DESCRIPTION
[PHP 8.5 Closures in constant expressions](https://wiki.php.net/rfc/closures_in_const_expr) are not supported yet. The plugin gracefully fails when it encounters a closure as an attribute argument. The README was updated with a workaround until I find a better solution.