### PR TITLE
Bump version requirements

### DIFF
--- a/.github/workflows/cases.yml
+++ b/.github/workflows/cases.yml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        includes:
-          - php-version: "8.0"
-            composer-version: "v2.3.0"
+        include:
+          - php-version: "8.2"
+            composer-version: "v2.9.8"
             composer-tweak: "--prefer-lowest"
           - php-version: "8.5"
             composer-version: "v2"
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        includes:
+        include:
           - php-version: "8.2"
-            composer-version: "v2.3.0"
+            composer-version: "v2.9.8"
           - php-version: "8.5"
             composer-version: "latest"
     steps:
@@ -55,9 +55,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        includes:
+        include:
           - php-version: "8.2"
-            composer-version: "v2.3.0"
+            composer-version: "v2.9.8"
           - php-version: "8.5"
             composer-version: "latest"
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        includes:
-          - php-version: "8.0"
+        include:
+          - php-version: "8.2"
             composer-tweak: "--prefer-lowest"
           - php-version: "8.5"
             composer-tweak: ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # CHANGELOG
 
+## v3.0.0
+
+### New Requirements
+
+- Bump PHP requirement from 8.0 to 8.2.
+- Bump Composer requirement from 2.3 to 2.9.8, following [security recommendation](https://blog.packagist.com/composer-2-9-8-and-2-2-28-fix-github-actions-token-disclosure-in-error-messages/).
+
+### New features
+
+None
+
+### Deprecated Features
+
+None
+
+### Backward Incompatible Changes
+
+None
+
+### Other Changes
+
+- Fix GitHub Action matrixes.
+
+
+
 ## v2.1.2
 
 ### New Requirements

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG PHP_TAG=8.0-cli-trixie
-ARG COMPOSER_TAG=2.3
+ARG PHP_TAG=8.2-cli-trixie
+ARG COMPOSER_TAG=2.9.8
 
 FROM composer:${COMPOSER_TAG} AS composer_source
 FROM php:${PHP_TAG}

--- a/Makefile
+++ b/Makefile
@@ -32,17 +32,7 @@ test-cleanup:
 	@rm -rf tests/sandbox/*
 
 .PHONY: test-container
-test-container: test-container80
-
-.PHONY: test-container80
-test-container80:
-	@-docker compose run --rm app80 bash
-	@docker compose down -v
-
-.PHONY: test-container81
-test-container81:
-	@-docker-compose run --rm app81 bash
-	@docker-compose down -v
+test-container: test-container82
 
 .PHONY: test-container82
 test-container82:

--- a/composer.json
+++ b/composer.json
@@ -33,12 +33,12 @@
     }
   },
   "require": {
-    "php": ">=8.0",
-    "composer-plugin-api": ">=2.3",
+    "php": ">=8.2",
+    "composer-plugin-api": "^2.3",
     "composer/class-map-generator": "^1.4"
   },
   "require-dev": {
-    "composer/composer": ">=2.3",
+    "composer/composer": "^2.9.8",
     "phpstan/phpstan": "^2.1.17",
     "phpunit/phpunit": "^9.6.23"
   },

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,28 +1,5 @@
 ---
 services:
-  app80:
-    build:
-      context: .
-      args:
-        PHP_TAG: '8.0-cli-bullseye'
-        COMPOSER_TAG: '2.3'
-    environment:
-      PHP_IDE_CONFIG: 'serverName=olvlvl/attribute-collector'
-    volumes:
-      - .:/app:delegated
-      - composer-cache:/root/.composer/cache
-    working_dir: /app
-  app81:
-    build:
-      context: .
-      args:
-        PHP_TAG: '8.1-cli-bullseye'
-    environment:
-      PHP_IDE_CONFIG: 'serverName=olvlvl/attribute-collector'
-    volumes:
-      - .:/app:delegated
-      - composer-cache:/root/.composer/cache
-    working_dir: /app
   app82:
     build:
       context: .

--- a/tests/CollectorTestAbstract.php
+++ b/tests/CollectorTestAbstract.php
@@ -42,8 +42,6 @@ use function is_string;
 use function str_contains;
 use function usort;
 
-use const PHP_VERSION_ID;
-
 abstract class CollectorTestAbstract extends TestCase
 {
     /**
@@ -84,10 +82,6 @@ abstract class CollectorTestAbstract extends TestCase
         $exclude = [
             "$cwd/tests/Acme/PSR4/IncompatibleSignature.php",
         ];
-
-        if (PHP_VERSION_ID < 80100) {
-            $exclude[] = "$cwd/tests/Acme81";
-        }
 
         return new Config(
             vendorDir: $vendorDir,
@@ -347,9 +341,6 @@ abstract class CollectorTestAbstract extends TestCase
         ], $this->collectMethods($actual));
     }
 
-    /**
-     * @requires PHP >= 8.1
-     */
     public function testFilterTargetMethods81(): void
     {
         $expected = [


### PR DESCRIPTION
## Context

The package currently targets PHP 8.0 as its minimum supported version. PHP 8.0 reached end-of-life and no longer receives security fixes; besides most users are already on PHP 8.2. Composer also released 2.9.8 to fix [a security issue](https://blog.packagist.com/composer-2-9-8-and-2-2-28-fix-github-actions-token-disclosure-in-error-messages/) (GitHub Actions token disclosure in error messages).

## Problem

The PHP 8.0 floor is spread across composer.json, the Docker images, the CI matrix, and the test bootstrap, while the Composer constraint (>=2.3) allows vulnerable older releases. Keeping PHP 8.0 means shipping an EOL runtime and outdated CI tooling.

## Goal

Raise the minimum PHP requirement from 8.0 to 8.2 and the minimum Composer from 2.3 to 2.9.8 across all tooling.

## Approach

- Update composer.json, Docker files, Makefile, and CI.
- Drop `PHP_VERSION_ID < 80100` checks.
- Add a v3.0.0 CHANGELOG entry.

## Validation

Regular testing.