### PR TITLE
Follow Composer's behavior for exclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### New features
 
 - [#60](https://github.com/olvlvl/composer-attribute-collector/pull/60) Track per-file mtime in `MemoizeClassMapGenerator`.
+- [#45](https://github.com/olvlvl/composer-attribute-collector/issues/45) The `exclude` directive now supports glob patterns, following Composer's `exclude-from-classmap` behavior.
 - An alternative generation strategy for maximum compatibility.
 
 ### Deprecated Features

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Here are a few ways you can configure the plugin.
 
 
 
-### Including paths or files ([root-only][])
+### Include paths or files ([root-only][])
 
 The collector automatically scans `autoload` paths of the root `composer.json`, but you can override
 them via the `include` property.
@@ -180,20 +180,23 @@ replaced with the path to the vendor folder.
 }
 ```
 
-### Excluding paths or files ([root-only][])
+### Exclude files from scanning ([root-only][])
 
-Use the `exclude` property to exclude paths or files from scanning. This is handy when files
+Use the `exclude` property to exclude some files or paths from scanning. This is handy when files
 cause issues or have side effects.
 
 The specified paths are relative to the `composer.json` file, and the `{vendor}` placeholder is
-replaced with the path to the vendor folder.
+replaced with the path to the vendor folder. Entries follow [Composer's `exclude-from-classmap`](https://getcomposer.org/doc/04-schema.md#exclude-files-from-classmaps)
+glob syntax: `*` matches anything but `/`, `**` matches anything, and `**` is implicitly added
+to the end of each path.
 
 ```json
 {
   "extra": {
     "composer-attribute-collector": {
       "exclude": [
-        "path-or-file/to/exclude"
+        "path-or-file/to/exclude",
+        "tests/**"
       ]
     }
   }

--- a/src/Config.php
+++ b/src/Config.php
@@ -5,11 +5,11 @@ namespace olvlvl\ComposerAttributeCollector;
 use Composer\Factory;
 use Composer\Package\PackageInterface;
 use Composer\PartialComposer;
+use Composer\Pcre\Preg;
 use Composer\Util\Platform;
 use InvalidArgumentException;
 use RuntimeException;
 
-use function array_map;
 use function dirname;
 use function filter_var;
 use function implode;
@@ -17,9 +17,11 @@ use function in_array;
 use function is_string;
 use function preg_quote;
 use function realpath;
+use function rtrim;
 use function str_ends_with;
 use function str_starts_with;
 use function strlen;
+use function strtr;
 
 use const DIRECTORY_SEPARATOR;
 
@@ -145,7 +147,7 @@ final readonly class Config
      * @param non-empty-string[] $include
      *     Paths that should be included in the attribute collection.
      * @param non-empty-string[] $exclude
-     *     Paths that should be excluded from the attribute collection.
+     *     Glob patterns for paths that should be excluded from the attribute collection.
      * @param bool $useCache
      *     Whether a cache should be used during the process.
      * @param bool $isDebug
@@ -166,15 +168,28 @@ final readonly class Config
     }
 
     /**
+     * Compiles the `exclude` patterns into a regular expression, following Composer's
+     * `exclude-from-classmap` behavior: `*` matches anything but `/`, `**` matches anything,
+     * and a path matches everything under it.
+     *
      * @param non-empty-string[] $exclude
      *
      * @return non-empty-string
      */
     private static function compileExclude(array $exclude): string
     {
-        $regexp = implode('|', array_map(fn (string $path) => preg_quote($path), $exclude));
+        $patterns = [];
 
-        return "($regexp)";
+        foreach ($exclude as $path) {
+            $path = strtr($path, '\\', '/');
+            $path = preg_quote(rtrim($path, '/'));
+            $path = Preg::replace('{/+}', '/', $path);
+            $path = strtr($path, [ '\\*\\*' => '.+?', '\\*' => '[^/]+?' ]);
+
+            $patterns[] = $path . '($|/)';
+        }
+
+        return '{(' . implode('|', $patterns) . ')}';
     }
 
     /**

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -6,8 +6,11 @@ use Composer\Package\RootPackageInterface;
 use Composer\PartialComposer;
 use Composer\Util\Platform;
 use olvlvl\ComposerAttributeCollector\Config;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+
+use function preg_match;
 
 final class ConfigTest extends TestCase
 {
@@ -165,5 +168,71 @@ final class ConfigTest extends TestCase
         $this->expectExceptionMessage("Unable to determine vendor directory");
 
         Config::from($composer);
+    }
+
+    #[DataProvider('provideExclude')]
+    public function testExclude(array $exclude, string $subject, bool $expected): void
+    {
+        $this->assertSame($expected, preg_match(self::excludeRegExp($exclude), $subject) === 1);
+    }
+
+    public function testNoExclude(): void
+    {
+        $config = new Config(
+            vendorDir: __DIR__,
+            attributesFile: __DIR__ . '/attributes.php',
+            include: [ __DIR__ ],
+            exclude: [],
+            useCache: false,
+            isDebug: false,
+        );
+
+        $this->assertNull($config->excludeRegExp);
+    }
+
+    /**
+     * @return array<string, array{ array<non-empty-string>, string, bool }>
+     */
+    public static function provideExclude(): array
+    {
+        return [
+            'literal directory matches a descendant' => [ [ '/src/Tests' ], '/src/Tests/Foo.php', true ],
+            'literal directory matches a nested descendant' => [ [ '/src/Tests' ], '/src/Tests/deep/Foo.php', true ],
+            'literal directory does not match a sibling file' => [ [ '/src/Tests' ], '/src/Tests.php', false ],
+            'literal directory does not match a prefix' => [ [ '/src/Tests' ], '/src/TestsFoo/Foo.php', false ],
+            'trailing separator directory is equivalent' => [ [ '/src/Tests/' ], '/src/Tests/Foo.php', true ],
+            'star matches within a path segment' => [ [ '/src/*.php' ], '/src/Foo.php', true ],
+            'star does not match across a slash' => [ [ '/src/*.php' ], '/src/deep/Foo.php', false ],
+            'double star matches a direct descendant' => [ [ '/src/**' ], '/src/Foo.php', true ],
+            'double star matches a nested descendant' => [ [ '/src/**' ], '/src/deep/Foo.php', true ],
+            'question mark is a literal' => [ [ '/src/?.php' ], '/src/Foo.php', false ],
+            'question mark matches a literal question mark' => [ [ '/src/?.php' ], '/src/?.php', true ],
+            'backslashes are normalized' => [ [ '\\src\\Tests' ], '/src/Tests/Foo.php', true ],
+            'patterns are OR-ed' => [ [ '/src/Tests', '/lib' ], '/lib/Foo.php', true ],
+            'unrelated path is kept' => [ [ '/src/Tests' ], '/lib/Foo.php', false ],
+        ];
+    }
+
+    /**
+     * @param non-empty-string[] $exclude
+     *
+     * @return non-empty-string
+     */
+    private static function excludeRegExp(array $exclude): string
+    {
+        $config = new Config(
+            vendorDir: __DIR__,
+            attributesFile: __DIR__ . '/attributes.php',
+            include: [ __DIR__ ],
+            exclude: $exclude,
+            useCache: false,
+            isDebug: false,
+        );
+
+        $regexp = $config->excludeRegExp;
+
+        self::assertNotNull($regexp);
+
+        return $regexp;
     }
 }


### PR DESCRIPTION
## Context

Fixes #45. As a Composer plugin, composer-attribute-collector should behave like Composer's. Composer filters classmap scanning with `exclude-from-classmap`, which supports glob patterns (`*` and `**`); the collector's `exclude` directive only accepted literal paths.

## Problem

For large monoliths, users must list every variant of a path individually. Because `exclude` entries were compiled with `preg_quote()` (exact-match), a layout like `apps/*/tests/` required one entry per `apps/<name>/tests/`:

```json
"exclude": [
  "apps/admin/tests/",
  "apps/main/tests/",
  "components/colors/tests/",
  "components/http/tests/",
  "components/math/tests/"
]
```

## Goal

Support `*` and `**` glob patterns in exclude, following [Composer's `exclude-from-classmap`](https://getcomposer.org/doc/04-schema.md#exclude-files-from-classmaps) semantics, so the above collapses to:

```json
"exclude": [
  "apps/**/tests/",
  "components/**/tests/"
]
```

## Approach

- Translate each exclude entry into a regex using the same logic as Composer's `AutoloadGenerator: normalize` separators, `preg_quote()`, then `**` → `.+?` and `*` → `[^/]+?`, and append `($|/)` so a path matches everything under it. Unlike `fnmatch()`, `*` deliberately does not cross `/`.
- Feed the compiled regex to Composer's `ClassMapGenerator::scanPaths()` through the existing `$excluded` argument, so exclusion happens during scanning — before any file is parsed or autoloaded. `Composer\Pcre\Preg` is already available as a transitive dependency of `composer/class-map-generator`.
- The `include` directive is unchanged: it remains a list of scan roots (paths/files), mirroring Composer's autoload model where glob filtering is exclusion-only.

## Validation

- Unit tests in `tests/ConfigTest.php` cover literal directory matching (descendants, nested, sibling/prefix boundaries), trailing-separator equivalence, `*` not crossing `/`, `**` crossing `/`, `?` being treated literally, backslash normalization, multiple-pattern OR-ing, and the empty case.
- Existing `StaticTest`/`ReferenceTest` still pass, exercising exclusion end-to-end through the collector.
